### PR TITLE
fix: Limit workspace chip width with text truncation

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -205,7 +205,16 @@ export function ProjectCard({
                 <Chip
                   startDecorator={<FolderOpen />}
                   onClick={handleOpenWorkDir}
-                  sx={{ cursor: 'pointer' }}
+                  sx={{
+                    cursor: 'pointer',
+                    maxWidth: '400px',
+                    '& > span': {
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      display: 'block',
+                    }
+                  }}
                 >
                   {project.workspaceDir}/apps/{getSanitizedAppName(project.name)}
                 </Chip>
@@ -290,7 +299,15 @@ export function ProjectCard({
                 <Typography
                   level="body-sm"
                   onClick={handleOpenWorkDir}
-                  sx={{ mt: 1, cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                  sx={{
+                    mt: 1,
+                    cursor: 'pointer',
+                    '&:hover': { textDecoration: 'underline' },
+                    maxWidth: '500px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
                 >
                   <strong>Work Dir:</strong> {project.workspaceDir}/apps/{getSanitizedAppName(project.name)}
                 </Typography>


### PR DESCRIPTION
- Add maxWidth (400px) to workspace Chip in card view
- Add maxWidth (500px) to workspace Typography in list view
- Apply text-overflow ellipsis for long workspace paths