### PR TITLE
fix(types): Fix TypeScript build errors in useSettings and AppConfig

### DIFF
--- a/src/hooks/useSettings.tsx
+++ b/src/hooks/useSettings.tsx
@@ -1,6 +1,9 @@
 import { useState, useCallback, useEffect } from 'react'
 import { ModelConfig } from '@/types/setupWizard'
 
+// AppConfig type from electron.d.ts (available globally, but we reference it for type annotations)
+type AppConfig = Parameters<typeof window.electronAPI.configSave>[0]
+
 export interface PlatformSettings {
   // Android settings
   androidScreenshotDir: string
@@ -197,7 +200,7 @@ export function useSettings() {
       // IMPORTANT: Load current config first to preserve all existing fields
       // This prevents overwriting fields that aren't in our React state
       const currentResult = await window.electronAPI.configLoad()
-      const currentConfig = currentResult.success && currentResult.config
+      const currentConfig: Partial<AppConfig> = currentResult.success && currentResult.config
         ? currentResult.config
         : { version: '1.0' }
 
@@ -206,51 +209,51 @@ export function useSettings() {
         ...currentConfig, // Preserve any existing fields
         version: '1.0',
         model: {
-          ...currentConfig.model, // Preserve existing model fields (e.g., MODEL)
+          ...(currentConfig.model || {}), // Preserve existing model fields (e.g., MODEL)
           enableLocal: modelConfig.enableLocal,
           enableApi: modelConfig.enableApi,
           api: {
-            ...currentConfig.model?.api, // Preserve existing API fields
+            ...(currentConfig.model?.api || {}), // Preserve existing API fields
             provider: modelConfig.apiProvider,
             baseUrl: modelConfig.apiBaseUrl,
             key: modelConfig.apiKey,
             model: modelConfig.apiModel,
           },
           local: {
-            ...currentConfig.model?.local, // Preserve existing local fields
+            ...(currentConfig.model?.local || {}), // Preserve existing local fields
             baseUrl: modelConfig.localBaseUrl,
             model: modelConfig.localModel,
           },
         },
         execution: {
-          ...currentConfig.execution, // Preserve existing execution fields
+          ...(currentConfig.execution || {}), // Preserve existing execution fields
           maxTokens: agentSettings.maxTokens,
           temperature: agentSettings.temperature,
           requestInterval: agentSettings.requestInterval,
           maxRounds: agentSettings.maxRounds,
         },
         android: {
-          ...currentConfig.android, // Preserve existing android fields
+          ...(currentConfig.android || {}), // Preserve existing android fields
           screenshotDir: platformSettings.androidScreenshotDir,
           xmlDir: platformSettings.androidXmlDir,
           sdkPath: platformSettings.androidSdkPath,
         },
         web: {
-          ...currentConfig.web, // Preserve existing web fields
+          ...(currentConfig.web || {}), // Preserve existing web fields
           browserType: platformSettings.webBrowserType,
           headless: platformSettings.webHeadless,
           viewportWidth: platformSettings.webViewportWidth,
           viewportHeight: platformSettings.webViewportHeight,
         },
         image: {
-          ...currentConfig.image, // Preserve existing image fields
+          ...(currentConfig.image || {}), // Preserve existing image fields
           maxWidth: imageSettings.imageMaxWidth,
           maxHeight: imageSettings.imageMaxHeight,
           quality: imageSettings.imageQuality,
           optimize: imageSettings.optimizeImages,
         },
         preferences: {
-          ...currentConfig.preferences, // Preserve existing preferences fields
+          ...(currentConfig.preferences || {}), // Preserve existing preferences fields
           darkMode: agentSettings.darkMode,
           minDist: agentSettings.minDist,
           docRefine: agentSettings.docRefine,

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -14,6 +14,7 @@ interface AppConfig {
     enableLocal: boolean;
     enableApi: boolean;
     api: {
+      provider?: string;
       baseUrl: string;
       key: string;
       model: string;


### PR DESCRIPTION
Fixed Vercel build failure caused by TypeScript compilation errors:

1. Added missing 'provider' field to AppConfig.model.api interface
   - Type definition in electron.d.ts was incomplete
   - Now matches the full AppConfig structure from main/types/config.ts

2. Fixed type narrowing issues in useSettings.tsx saveSettings function
   - Added explicit Partial<AppConfig> type annotation for currentConfig
   - Wrapped all spread operations with || {} to safely handle undefined values
   - Prevents "Property does not exist" errors when spreading partial config

These changes resolve all 9 TypeScript errors reported in the Vercel build log.