### PR TITLE
refactor: Rename "Self Explorer" to "Klever" in UI

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -60,7 +60,7 @@ export function Layout() {
           <Box
             component="img"
             src={logo}
-            alt="Self Explorer Logo"
+            alt="Klever Logo"
             sx={{
               height: 40,
               width: 40,
@@ -73,7 +73,7 @@ export function Layout() {
               display: { xs: 'none', sm: 'block' },
             }}
           >
-            Self Explorer
+            Klever
           </Typography>
         </Stack>
 


### PR DESCRIPTION
Update the application header to display "Klever" instead of "Self Explorer"
to match the product name. This change only affects user-facing UI text
and does not modify internal code references or file names.

Changes:
- Update logo alt text: "Self Explorer Logo" → "Klever Logo"
- Update header title: "Self Explorer" → "Klever"