### PR TITLE
fix: Set explicit appBundleId for macOS builds

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -16,6 +16,7 @@ module.exports = {
       identity: process.env.CSC_NAME, // Apple Distribution
       platform: 'mas',
       type: 'distribution',
+      appBundleId: 'com.klever.desktop', // MUST match App Store Connect
       entitlements: 'build/entitlements.mas.plist',
       'entitlements-inherit': 'build/entitlements.mas.inherit.plist',
     }


### PR DESCRIPTION
- Add appBundleId: 'com.klever.desktop' to osxSign config
- Prevents Electron from auto-generating 'com.electron.klever-desktop'
- Ensures bundle identifier matches App Store Connect registration