### PR TITLE
feat: Add GitHub Actions Mac App Store build pipeline

### DIFF
--- a/.github/ACTIONS_README.md
+++ b/.github/ACTIONS_README.md
@@ -1,0 +1,452 @@
+# GitHub Actions 자동 빌드 파이프라인
+
+Mac App Store용 자동 빌드·배포 파이프라인 가이드입니다.
+
+## 📖 목차
+
+1. [개요](#개요)
+2. [빠른 시작](#빠른-시작)
+3. [워크플로우 동작 방식](#워크플로우-동작-방식)
+4. [트리거 조건](#트리거-조건)
+5. [수동 실행](#수동-실행)
+6. [문제 해결](#문제-해결)
+
+---
+
+## 개요
+
+이 파이프라인은 다음을 자동화합니다:
+
+```
+코드 변경 → 빌드 → 서명 → 업로드 → App Store Connect
+```
+
+### 자동화되는 작업
+
+✅ **인증서 설치** - Apple Distribution 및 Installer 인증서 자동 설치
+✅ **프로비저닝 프로파일** - Mac App Store 프로파일 자동 설치
+✅ **Universal 빌드** - x64 + ARM64 통합 바이너리 생성
+✅ **코드 서명** - 모든 Electron 프로세스 서명
+✅ **PKG 생성** - App Store 배포용 패키지 생성
+✅ **자동 업로드** - App Store Connect에 자동 업로드
+✅ **정리** - 빌드 완료 후 아티팩트 자동 삭제
+
+---
+
+## 빠른 시작
+
+### 1️⃣ GitHub Secrets 설정
+
+먼저 필요한 인증 정보를 GitHub Secrets에 추가해야 합니다.
+
+📚 **상세 가이드**: [GITHUB_SECRETS_SETUP.md](./GITHUB_SECRETS_SETUP.md)
+
+#### 필수 Secrets 목록
+
+| Secret 이름 | 설명 |
+|------------|------|
+| `APPLE_ID` | Apple ID 이메일 |
+| `APPLE_APP_SPECIFIC_PASSWORD` | 앱 전용 암호 |
+| `APPLE_TEAM_ID` | Apple Developer Team ID |
+| `CSC_NAME` | Apple Distribution 인증서 이름 |
+| `CSC_INSTALLER_NAME` | Installer 인증서 이름 |
+| `CERTIFICATE_P12_BASE64` | Apple Distribution 인증서 (Base64) |
+| `CERTIFICATE_PASSWORD` | Apple Distribution 인증서 비밀번호 |
+| `INSTALLER_CERTIFICATE_P12_BASE64` | Installer 인증서 (Base64) |
+| `INSTALLER_CERTIFICATE_PASSWORD` | Installer 인증서 비밀번호 |
+| `PROVISIONING_PROFILE_BASE64` | 프로비저닝 프로파일 (Base64) |
+
+#### 빠른 인코딩
+
+인증서와 프로파일을 Base64로 인코딩:
+
+```bash
+# 스크립트 사용 (권장)
+./scripts/encode-secrets.sh certificate.p12 installer.p12 embedded.provisionprofile
+
+# 수동 인코딩
+base64 -i certificate.p12 | pbcopy  # macOS
+base64 -w 0 certificate.p12         # Linux
+```
+
+---
+
+### 2️⃣ 버전/빌드 번호 업데이트
+
+파이프라인은 다음 파일의 변경을 감지합니다:
+
+#### 앱 버전 변경 (`package.json`)
+
+```json
+{
+  "version": "2.0.0"  // → "2.1.0"으로 변경
+}
+```
+
+#### 빌드 번호 변경 (`forge.config.js`)
+
+```javascript
+module.exports = {
+  packagerConfig: {
+    buildVersion: '13',  // → '14'로 변경
+    // ...
+  },
+  // ...
+}
+```
+
+---
+
+### 3️⃣ Push 및 자동 실행
+
+```bash
+# 변경사항 커밋
+git add package.json forge.config.js
+git commit -m "chore: bump version to 2.1.0 (build 14)"
+
+# main 브랜치에 푸시
+git push origin main
+```
+
+푸시 즉시 GitHub Actions가 자동으로 실행됩니다!
+
+---
+
+## 워크플로우 동작 방식
+
+### 전체 플로우
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. Checkout Code                                            │
+├─────────────────────────────────────────────────────────────┤
+│ 2. Extract Version & Build Number                           │
+│    - package.json → version                                 │
+│    - forge.config.js → buildVersion                         │
+├─────────────────────────────────────────────────────────────┤
+│ 3. Setup Node.js 20 + npm ci                                │
+├─────────────────────────────────────────────────────────────┤
+│ 4. Install Apple Certificates                               │
+│    - Decode Base64 → .p12 files                             │
+│    - Create temporary keychain                              │
+│    - Import certificates to keychain                        │
+├─────────────────────────────────────────────────────────────┤
+│ 5. Install Provisioning Profile                             │
+│    - Decode Base64 → .provisionprofile                      │
+│    - Extract UUID                                           │
+│    - Install to ~/Library/MobileDevice/Provisioning Profiles│
+├─────────────────────────────────────────────────────────────┤
+│ 6. Build MAS Universal                                      │
+│    - npm run make -- --platform=mas --arch=universal        │
+│    - Sign all Electron processes                            │
+│    - Create PKG for App Store                               │
+├─────────────────────────────────────────────────────────────┤
+│ 7. Verify Build                                             │
+│    - Check PKG file exists                                  │
+│    - Verify PKG signature                                   │
+├─────────────────────────────────────────────────────────────┤
+│ 8. Upload to App Store Connect                              │
+│    - Run scripts/upload-appstore.sh                         │
+│    - Upload via xcrun altool                                │
+├─────────────────────────────────────────────────────────────┤
+│ 9. Upload Artifacts (GitHub)                                │
+│    - Save PKG for 30 days                                   │
+├─────────────────────────────────────────────────────────────┤
+│ 10. Cleanup                                                 │
+│    - Delete keychain                                        │
+│    - Remove provisioning profiles                           │
+│    - Delete build artifacts (if upload succeeded)           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 빌드 시간
+
+- **전체 소요 시간**: 약 15-25분
+  - 환경 설정: 2-3분
+  - 빌드: 8-12분
+  - 업로드: 5-10분
+
+---
+
+## 트리거 조건
+
+워크플로우는 다음 조건에서 자동 실행됩니다:
+
+### 1. 파일 변경 감지 (push to main)
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'           # 앱 버전 변경
+      - 'forge.config.js'        # 빌드 번호 변경
+```
+
+### 2. 워크플로우 자체 수정
+
+```yaml
+paths:
+  - '.github/workflows/build-mas.yml'  # 워크플로우 변경 시 테스트
+```
+
+### 3. 수동 실행
+
+GitHub UI에서 언제든지 수동 실행 가능:
+
+```yaml
+on:
+  workflow_dispatch:  # "Run workflow" 버튼 활성화
+```
+
+---
+
+## 수동 실행
+
+자동 트리거 없이 언제든지 수동으로 실행할 수 있습니다.
+
+### 방법 1: GitHub UI
+
+1. **Repository** → **Actions** 탭 클릭
+2. **"Build & Upload Mac App Store"** 워크플로우 선택
+3. **"Run workflow"** 드롭다운 클릭
+4. 브랜치 선택 (기본값: main)
+5. **"Run workflow"** 버튼 클릭
+
+### 방법 2: GitHub CLI
+
+```bash
+# 설치 (없는 경우)
+brew install gh
+
+# 인증
+gh auth login
+
+# 워크플로우 실행
+gh workflow run build-mas.yml
+
+# 실행 상태 확인
+gh run list --workflow=build-mas.yml
+```
+
+---
+
+## 빌드 상태 확인
+
+### GitHub Actions UI
+
+1. **Repository** → **Actions** 탭
+2. 최신 워크플로우 실행 클릭
+3. 각 단계별 로그 확인
+
+### 주요 확인 포인트
+
+- ✅ **Install Apple certificates** - 인증서 설치 성공 여부
+- ✅ **Build MAS Universal** - 빌드 성공 여부
+- ✅ **Verify build artifacts** - PKG 서명 검증
+- ✅ **Upload to App Store Connect** - 업로드 성공 여부
+
+### App Store Connect 확인
+
+업로드 완료 후:
+
+1. https://appstoreconnect.apple.com 방문
+2. **앱 선택** → **Activity** 탭
+3. **Processing** 상태 확인 (5-30분 소요)
+4. 처리 완료 후 **빌드 선택** → **Submit for Review**
+
+---
+
+## 문제 해결
+
+### 🔴 인증서 설치 실패
+
+**증상**: "Install Apple certificates" 단계 실패
+
+**원인**:
+- Base64 디코딩 실패
+- 잘못된 인증서 비밀번호
+
+**해결**:
+1. Secrets 확인: `CERTIFICATE_P12_BASE64` 올바른지 확인
+2. 비밀번호 확인: `CERTIFICATE_PASSWORD` 정확한지 확인
+3. 재인코딩: `./scripts/encode-secrets.sh` 재실행
+
+---
+
+### 🔴 빌드 서명 실패
+
+**증상**: "Build MAS Universal" 단계에서 서명 오류
+
+**원인**:
+- 인증서 이름 불일치
+- 프로비저닝 프로파일 문제
+
+**해결**:
+```bash
+# 로컬에서 인증서 이름 확인
+security find-identity -v -p codesigning
+
+# 출력 예시:
+# 1) ABC123 "Apple Distribution: Your Name (TEAM_ID)"
+# 2) DEF456 "3rd Party Mac Developer Installer: Your Name (TEAM_ID)"
+
+# GitHub Secrets의 CSC_NAME과 정확히 일치하는지 확인
+```
+
+---
+
+### 🔴 업로드 실패
+
+**증상**: "Upload to App Store Connect" 단계 실패
+
+**원인**:
+- 잘못된 Apple ID 정보
+- 만료된 App-Specific Password
+- 네트워크 오류
+
+**해결**:
+1. **App-Specific Password 재생성**:
+   - https://appleid.apple.com/account/manage
+   - 새 암호 생성
+   - GitHub Secrets 업데이트
+
+2. **Team ID 확인**:
+   - https://developer.apple.com/account/#!/membership
+   - `APPLE_TEAM_ID` Secret 확인
+
+3. **재시도**: 네트워크 일시적 오류일 수 있음
+
+---
+
+### 🔴 빌드는 성공했으나 App Store Connect에 표시 안 됨
+
+**증상**: 업로드 성공 메시지는 나왔지만 App Store Connect에 빌드가 안 보임
+
+**원인**:
+- Processing 중 (최대 30분 소요)
+- Bundle ID 불일치
+- 앱이 App Store Connect에 생성되지 않음
+
+**해결**:
+1. **Processing 대기**: 5-30분 대기 후 새로고침
+2. **이메일 확인**: Apple에서 오류 이메일 발송 여부 확인
+3. **Bundle ID 확인**:
+   ```javascript
+   // forge.config.js
+   appBundleId: 'com.klever.desktop'  // App Store Connect와 일치해야 함
+   ```
+
+---
+
+### 🔴 정리 단계 실패
+
+**증상**: "Cleanup" 단계 오류
+
+**원인**: 권한 문제 (무시해도 됨)
+
+**영향**: 없음 (GitHub Actions runner는 매번 새로 생성됨)
+
+---
+
+## 보안 고려사항
+
+### ✅ Secrets 관리
+
+- **절대 코드에 하드코딩 금지**
+- **Secrets는 GitHub UI에서만 관리**
+- **로컬 인증서 파일은 즉시 삭제**
+
+### ✅ 인증서 보호
+
+```bash
+# ❌ 절대 금지
+git add certificate.p12
+git commit -m "Add certificate"
+
+# ✅ 올바른 방법
+./scripts/encode-secrets.sh certificate.p12 installer.p12 profile.provisionprofile
+# → GitHub Secrets에 추가
+rm certificate.p12 installer.p12 profile.provisionprofile  # 즉시 삭제
+```
+
+### ✅ .gitignore 확인
+
+```gitignore
+# 인증서 및 프로파일 (절대 커밋 금지)
+*.p12
+*.mobileprovision
+*.provisionprofile
+*.cer
+*.certSigningRequest
+
+# 환경 변수
+.env
+.env.local
+.env.*.local
+```
+
+---
+
+## 고급 사용법
+
+### 특정 브랜치에서 빌드
+
+```yaml
+# .github/workflows/build-mas.yml 수정
+on:
+  push:
+    branches:
+      - main
+      - release/*  # release/v2.0.0 등에서도 실행
+```
+
+### 태그 기반 트리거
+
+```yaml
+on:
+  push:
+    tags:
+      - 'v*'  # v2.0.0 태그 푸시 시 실행
+```
+
+### 빌드 시간 단축
+
+```yaml
+# 캐시 활용
+- name: Cache node modules
+  uses: actions/cache@v3
+  with:
+    path: node_modules
+    key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+```
+
+---
+
+## 추가 자료
+
+- 📚 [GitHub Secrets 설정 가이드](./GITHUB_SECRETS_SETUP.md)
+- 📚 [Mac App Store 빌드 가이드](../MAS_BUILD_TROUBLESHOOTING.md)
+- 🔗 [Electron - MAS Submission Guide](https://www.electronjs.org/docs/latest/tutorial/mac-app-store-submission-guide)
+- 🔗 [GitHub Actions - Encrypted Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+- 🔗 [Apple - App Store Connect](https://developer.apple.com/app-store-connect/)
+
+---
+
+## 지원
+
+문제가 발생하면:
+
+1. **Actions 로그 확인**: 상세한 에러 메시지 확인
+2. **문제 해결 섹션** 참조
+3. **Issue 생성**: 로그와 함께 이슈 등록
+
+---
+
+## 변경 이력
+
+- **2024-11-21**: 초기 버전 작성
+  - Mac App Store 자동 빌드 파이프라인 구축
+  - Universal binary 지원
+  - 자동 업로드 기능 추가

--- a/.github/GITHUB_SECRETS_SETUP.md
+++ b/.github/GITHUB_SECRETS_SETUP.md
@@ -1,0 +1,234 @@
+# GitHub Secrets 설정 가이드
+
+이 문서는 Mac App Store 자동 빌드 파이프라인에 필요한 GitHub Secrets를 설정하는 방법을 안내합니다.
+
+## 📋 필요한 Secrets 목록
+
+### 1. Apple 계정 정보
+- `APPLE_ID` - Apple ID 이메일
+- `APPLE_APP_SPECIFIC_PASSWORD` - 앱 전용 암호
+- `APPLE_TEAM_ID` - Apple Developer Team ID
+
+### 2. 코드 서명 인증서 정보
+- `CSC_NAME` - Apple Distribution 인증서 이름
+- `CSC_INSTALLER_NAME` - Installer 인증서 이름
+
+### 3. 인증서 파일 (Base64 인코딩)
+- `CERTIFICATE_P12_BASE64` - Apple Distribution 인증서 (Base64)
+- `CERTIFICATE_PASSWORD` - Apple Distribution 인증서 비밀번호
+- `INSTALLER_CERTIFICATE_P12_BASE64` - Installer 인증서 (Base64)
+- `INSTALLER_CERTIFICATE_PASSWORD` - Installer 인증서 비밀번호
+
+### 4. 프로비저닝 프로파일
+- `PROVISIONING_PROFILE_BASE64` - Mac App Store 프로비저닝 프로파일 (Base64)
+
+---
+
+## 🔧 설정 단계
+
+### Step 1: Apple 계정 정보 수집
+
+#### 1.1. Apple ID
+- 본인의 Apple ID 이메일 주소
+
+#### 1.2. App-Specific Password 생성
+1. https://appleid.apple.com 방문
+2. "Sign-In and Security" → "App-Specific Passwords" 클릭
+3. "Generate Password" 클릭
+4. 이름 입력 (예: "GitHub Actions")
+5. 생성된 암호 복사 (형식: `xxxx-xxxx-xxxx-xxxx`)
+
+#### 1.3. Team ID 확인
+1. https://developer.apple.com/account/#!/membership 방문
+2. "Team ID" 확인 (예: `ZQC7QNZ4J8`)
+
+---
+
+### Step 2: 코드 서명 인증서 정보 확인
+
+#### 2.1. CSC_NAME (Apple Distribution)
+터미널에서 다음 명령어 실행:
+```bash
+security find-identity -v -p codesigning
+```
+
+출력 예시:
+```
+1) 1234567890ABCDEF "Apple Distribution: Your Name (TEAM_ID)"
+2) 0987654321FEDCBA "3rd Party Mac Developer Installer: Your Name (TEAM_ID)"
+```
+
+`CSC_NAME`에 사용할 값:
+```
+Apple Distribution: Your Name (TEAM_ID)
+```
+
+#### 2.2. CSC_INSTALLER_NAME (Installer)
+위 명령어 출력에서 "3rd Party Mac Developer Installer" 라인 복사:
+```
+3rd Party Mac Developer Installer: Your Name (TEAM_ID)
+```
+
+---
+
+### Step 3: 인증서를 P12 파일로 내보내기
+
+#### 3.1. Keychain Access 열기
+1. Applications → Utilities → Keychain Access
+
+#### 3.2. Apple Distribution 인증서 내보내기
+1. "My Certificates" 카테고리 선택
+2. "Apple Distribution: Your Name (TEAM_ID)" 인증서 찾기
+3. 인증서와 **개인 키 모두 선택** (화살표 펼쳐서 확인)
+4. 우클릭 → "Export 2 items..." 선택
+5. 파일명: `certificate.p12`
+6. 암호 입력 (나중에 `CERTIFICATE_PASSWORD`로 사용)
+7. 저장
+
+#### 3.3. Installer 인증서 내보내기
+1. "3rd Party Mac Developer Installer: Your Name (TEAM_ID)" 인증서 찾기
+2. 인증서와 **개인 키 모두 선택**
+3. 우클릭 → "Export 2 items..."
+4. 파일명: `installer.p12`
+5. 암호 입력 (나중에 `INSTALLER_CERTIFICATE_PASSWORD`로 사용)
+6. 저장
+
+---
+
+### Step 4: 프로비저닝 프로파일 다운로드
+
+#### 4.1. Apple Developer 포털
+1. https://developer.apple.com/account/resources/profiles/list 방문
+2. Mac App Store용 프로비저닝 프로파일 찾기
+3. 다운로드 (파일명: `embedded.provisionprofile` 또는 유사)
+
+또는 로컬에 이미 있는 경우:
+```bash
+# 프로비저닝 프로파일 위치
+ls ~/Library/MobileDevice/Provisioning\ Profiles/
+```
+
+---
+
+### Step 5: 파일을 Base64로 인코딩
+
+프로젝트 루트에 `scripts/encode-secrets.sh` 스크립트를 사용하거나 수동으로 인코딩:
+
+#### 5.1. 수동 인코딩 (macOS/Linux)
+```bash
+# Apple Distribution 인증서
+base64 -i certificate.p12 | pbcopy
+# 클립보드에 복사됨 → CERTIFICATE_P12_BASE64
+
+# Installer 인증서
+base64 -i installer.p12 | pbcopy
+# 클립보드에 복사됨 → INSTALLER_CERTIFICATE_P12_BASE64
+
+# 프로비저닝 프로파일
+base64 -i embedded.provisionprofile | pbcopy
+# 클립보드에 복사됨 → PROVISIONING_PROFILE_BASE64
+```
+
+#### 5.2. 스크립트 사용 (권장)
+```bash
+# 인코딩 스크립트 실행
+chmod +x scripts/encode-secrets.sh
+./scripts/encode-secrets.sh certificate.p12 installer.p12 embedded.provisionprofile
+```
+
+출력된 Base64 문자열을 복사하여 GitHub Secrets에 추가합니다.
+
+---
+
+### Step 6: GitHub Repository에 Secrets 추가
+
+1. **GitHub Repository 페이지** 이동
+2. **Settings** 탭 클릭
+3. **Secrets and variables** → **Actions** 클릭
+4. **New repository secret** 클릭
+
+각 Secret을 다음과 같이 추가:
+
+| Secret Name | Value | 예시 |
+|-------------|-------|------|
+| `APPLE_ID` | Apple ID 이메일 | `your@email.com` |
+| `APPLE_APP_SPECIFIC_PASSWORD` | 앱 전용 암호 | `xxxx-xxxx-xxxx-xxxx` |
+| `APPLE_TEAM_ID` | Team ID | `ZQC7QNZ4J8` |
+| `CSC_NAME` | Apple Distribution 인증서 이름 | `Apple Distribution: Your Name (TEAM_ID)` |
+| `CSC_INSTALLER_NAME` | Installer 인증서 이름 | `3rd Party Mac Developer Installer: Your Name (TEAM_ID)` |
+| `CERTIFICATE_P12_BASE64` | Apple Distribution 인증서 Base64 | (Step 5에서 복사한 긴 문자열) |
+| `CERTIFICATE_PASSWORD` | Apple Distribution 인증서 비밀번호 | (Step 3.2에서 설정한 암호) |
+| `INSTALLER_CERTIFICATE_P12_BASE64` | Installer 인증서 Base64 | (Step 5에서 복사한 긴 문자열) |
+| `INSTALLER_CERTIFICATE_PASSWORD` | Installer 인증서 비밀번호 | (Step 3.3에서 설정한 암호) |
+| `PROVISIONING_PROFILE_BASE64` | 프로비저닝 프로파일 Base64 | (Step 5에서 복사한 긴 문자열) |
+
+---
+
+## ✅ 설정 확인
+
+모든 Secrets를 추가한 후:
+
+1. **GitHub Actions** 탭으로 이동
+2. **"Build & Upload Mac App Store"** 워크플로우 선택
+3. **"Run workflow"** 클릭하여 수동 실행
+4. 로그를 확인하여 인증서 설치 및 빌드가 성공하는지 확인
+
+---
+
+## 🔒 보안 주의사항
+
+1. **.p12 파일과 프로비저닝 프로파일은 로컬에서 삭제**
+   - Base64 인코딩 후 GitHub Secrets에 추가했다면 로컬 파일은 안전하게 삭제
+
+2. **앱 전용 암호 재사용 금지**
+   - GitHub Actions 전용으로 별도 생성
+   - 필요시 언제든지 재발급 가능
+
+3. **인증서 비밀번호는 강력하게 설정**
+   - 최소 12자 이상 권장
+
+4. **Secrets는 절대 코드에 하드코딩하지 않기**
+   - 모든 민감 정보는 GitHub Secrets로 관리
+
+---
+
+## 🚀 자동화 트리거
+
+설정 완료 후, 다음 조건에서 자동 빌드가 실행됩니다:
+
+1. **`package.json`의 `version` 변경**
+   - 예: `2.0.0` → `2.1.0`
+
+2. **`forge.config.js`의 `buildVersion` 변경**
+   - 예: `buildVersion: '13'` → `buildVersion: '14'`
+
+3. **수동 실행**
+   - GitHub Actions 탭에서 "Run workflow" 클릭
+
+---
+
+## ❓ 문제 해결
+
+### 인증서 설치 실패
+- **원인**: Base64 디코딩 실패 또는 잘못된 암호
+- **해결**: Base64 문자열과 암호를 다시 확인
+
+### 빌드 서명 실패
+- **원인**: 인증서 이름 불일치
+- **해결**: `security find-identity -v -p codesigning` 출력과 정확히 일치하는지 확인
+
+### 업로드 실패
+- **원인**: 잘못된 Apple ID 정보 또는 네트워크 문제
+- **해결**: App-Specific Password 재생성 또는 재시도
+
+### 프로비저닝 프로파일 오류
+- **원인**: 만료되었거나 Bundle ID 불일치
+- **해결**: Apple Developer 포털에서 새 프로파일 생성
+
+---
+
+## 📚 추가 자료
+
+- [Apple Developer - App Store Connect](https://developer.apple.com/app-store-connect/)
+- [Electron - Mac App Store Submission Guide](https://www.electronjs.org/docs/latest/tutorial/mac-app-store-submission-guide)
+- [GitHub - Encrypted Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)

--- a/.github/QUICKSTART_CHECKLIST.md
+++ b/.github/QUICKSTART_CHECKLIST.md
@@ -1,0 +1,243 @@
+# 🚀 빠른 시작 체크리스트
+
+GitHub Actions 자동 빌드 파이프라인 설정을 위한 단계별 체크리스트입니다.
+
+---
+
+## ✅ 사전 준비 (로컬)
+
+### 1. 인증서 내보내기
+
+- [ ] **Keychain Access** 실행
+- [ ] **"Apple Distribution: Your Name (TEAM_ID)"** 인증서 찾기
+- [ ] 인증서 + 개인 키 선택 → 우클릭 → **"Export 2 items..."**
+- [ ] 파일명: `certificate.p12`, 암호 설정 (나중에 `CERTIFICATE_PASSWORD`로 사용)
+- [ ] 저장 위치 기억 (예: `~/Desktop/certificate.p12`)
+
+- [ ] **"3rd Party Mac Developer Installer: Your Name (TEAM_ID)"** 인증서 찾기
+- [ ] 인증서 + 개인 키 선택 → 우클릭 → **"Export 2 items..."**
+- [ ] 파일명: `installer.p12`, 암호 설정 (나중에 `INSTALLER_CERTIFICATE_PASSWORD`로 사용)
+- [ ] 저장 위치 기억 (예: `~/Desktop/installer.p12`)
+
+---
+
+### 2. 프로비저닝 프로파일 다운로드
+
+- [ ] https://developer.apple.com/account/resources/profiles/list 방문
+- [ ] Mac App Store용 프로파일 찾기
+- [ ] 다운로드 → 저장 위치 기억 (예: `~/Desktop/embedded.provisionprofile`)
+
+또는 로컬에 있는 경우:
+```bash
+ls ~/Library/MobileDevice/Provisioning\ Profiles/
+```
+
+---
+
+### 3. Base64 인코딩
+
+#### 방법 A: 스크립트 사용 (권장)
+
+```bash
+cd /path/to/KleverDesktop
+./scripts/encode-secrets.sh ~/Desktop/certificate.p12 ~/Desktop/installer.p12 ~/Desktop/embedded.provisionprofile
+```
+
+- [ ] 스크립트 실행
+- [ ] 출력된 Base64 문자열 복사 준비
+
+#### 방법 B: 수동 인코딩
+
+```bash
+# Apple Distribution 인증서
+base64 -i ~/Desktop/certificate.p12 | pbcopy
+
+# Installer 인증서
+base64 -i ~/Desktop/installer.p12 | pbcopy
+
+# 프로비저닝 프로파일
+base64 -i ~/Desktop/embedded.provisionprofile | pbcopy
+```
+
+- [ ] 각 파일 인코딩 후 Base64 문자열 저장
+
+---
+
+### 4. Apple 정보 수집
+
+#### Apple ID
+- [ ] Apple ID 이메일 주소 확인 (예: `your@email.com`)
+
+#### App-Specific Password
+- [ ] https://appleid.apple.com/account/manage 방문
+- [ ] "Sign-In and Security" → "App-Specific Passwords"
+- [ ] "Generate Password" 클릭
+- [ ] 이름 입력: "GitHub Actions"
+- [ ] 생성된 암호 복사 (형식: `xxxx-xxxx-xxxx-xxxx`)
+
+#### Team ID
+- [ ] https://developer.apple.com/account/#!/membership 방문
+- [ ] "Team ID" 확인 (예: `ZQC7QNZ4J8`)
+
+---
+
+### 5. 인증서 이름 확인
+
+```bash
+security find-identity -v -p codesigning
+```
+
+출력에서:
+- [ ] **CSC_NAME** 복사 (예: `Apple Distribution: Your Name (TEAM_ID)`)
+- [ ] **CSC_INSTALLER_NAME** 복사 (예: `3rd Party Mac Developer Installer: Your Name (TEAM_ID)`)
+
+---
+
+## ✅ GitHub 설정
+
+### 6. GitHub Secrets 추가
+
+**Repository** → **Settings** → **Secrets and variables** → **Actions** → **New repository secret**
+
+각 Secret 추가:
+
+#### Apple 계정 정보
+- [ ] `APPLE_ID` = `your@email.com`
+- [ ] `APPLE_APP_SPECIFIC_PASSWORD` = `xxxx-xxxx-xxxx-xxxx`
+- [ ] `APPLE_TEAM_ID` = `ZQC7QNZ4J8`
+
+#### 인증서 정보
+- [ ] `CSC_NAME` = `Apple Distribution: Your Name (TEAM_ID)`
+- [ ] `CSC_INSTALLER_NAME` = `3rd Party Mac Developer Installer: Your Name (TEAM_ID)`
+
+#### 인증서 파일 (Base64)
+- [ ] `CERTIFICATE_P12_BASE64` = (Step 3에서 복사한 Base64 문자열)
+- [ ] `CERTIFICATE_PASSWORD` = (Step 1에서 설정한 certificate.p12 비밀번호)
+- [ ] `INSTALLER_CERTIFICATE_P12_BASE64` = (Step 3에서 복사한 Base64 문자열)
+- [ ] `INSTALLER_CERTIFICATE_PASSWORD` = (Step 1에서 설정한 installer.p12 비밀번호)
+
+#### 프로비저닝 프로파일
+- [ ] `PROVISIONING_PROFILE_BASE64` = (Step 3에서 복사한 Base64 문자열)
+
+---
+
+### 7. Secrets 확인
+
+- [ ] 총 **10개** Secrets가 추가되었는지 확인
+- [ ] 각 Secret 이름 오타 없는지 확인 (대소문자 구분!)
+
+---
+
+## ✅ 로컬 정리
+
+### 8. 민감한 파일 삭제
+
+```bash
+# 인증서 및 프로파일 삭제
+rm ~/Desktop/certificate.p12
+rm ~/Desktop/installer.p12
+rm ~/Desktop/embedded.provisionprofile
+```
+
+- [ ] 인증서 파일 삭제 확인
+- [ ] 프로비저닝 프로파일 삭제 확인
+- [ ] 휴지통 비우기
+
+---
+
+## ✅ 테스트 실행
+
+### 9. 수동 워크플로우 실행
+
+- [ ] **GitHub Repository** 이동
+- [ ] **Actions** 탭 클릭
+- [ ] **"Build & Upload Mac App Store"** 워크플로우 선택
+- [ ] **"Run workflow"** 드롭다운 클릭
+- [ ] 브랜치 선택: `main`
+- [ ] **"Run workflow"** 버튼 클릭
+
+---
+
+### 10. 빌드 상태 모니터링
+
+- [ ] 워크플로우 실행 클릭하여 로그 확인
+- [ ] **"Install Apple certificates"** 단계 성공 확인
+- [ ] **"Build MAS Universal"** 단계 성공 확인
+- [ ] **"Upload to App Store Connect"** 단계 성공 확인
+
+---
+
+### 11. App Store Connect 확인
+
+- [ ] https://appstoreconnect.apple.com 방문
+- [ ] 앱 선택 → **Activity** 탭
+- [ ] Processing 상태 확인 (5-30분 대기)
+- [ ] 빌드 처리 완료 확인
+
+---
+
+## ✅ 자동화 설정 (선택사항)
+
+### 12. 버전/빌드 번호 변경으로 자동 트리거 테스트
+
+#### package.json 수정
+```json
+{
+  "version": "2.0.1"  // 버전 증가
+}
+```
+
+#### forge.config.js 수정
+```javascript
+buildVersion: '14',  // 빌드 번호 증가
+```
+
+#### Commit & Push
+```bash
+git add package.json forge.config.js
+git commit -m "chore: bump version to 2.0.1 (build 14)"
+git push origin main
+```
+
+- [ ] 변경사항 커밋 및 푸시
+- [ ] GitHub Actions 자동 실행 확인
+- [ ] 빌드 성공 확인
+
+---
+
+## 🎉 완료!
+
+모든 체크박스를 완료했다면 자동 빌드 파이프라인이 정상 작동하는 것입니다!
+
+---
+
+## 📚 추가 자료
+
+- [상세 설정 가이드](./GITHUB_SECRETS_SETUP.md)
+- [사용 가이드](./ACTIONS_README.md)
+- [문제 해결](../MAS_BUILD_TROUBLESHOOTING.md)
+
+---
+
+## 🔍 문제 발생 시
+
+### 인증서 설치 실패
+→ [문제 해결: 인증서 설치](./ACTIONS_README.md#🔴-인증서-설치-실패)
+
+### 빌드 서명 실패
+→ [문제 해결: 빌드 서명](./ACTIONS_README.md#🔴-빌드-서명-실패)
+
+### 업로드 실패
+→ [문제 해결: 업로드](./ACTIONS_README.md#🔴-업로드-실패)
+
+---
+
+## ⏱️ 예상 소요 시간
+
+- **초기 설정**: 30-60분
+- **테스트 실행**: 15-25분 (빌드 + 업로드)
+- **총 소요 시간**: 약 1-1.5시간
+
+---
+
+**마지막 업데이트**: 2024-11-21

--- a/.github/workflows/build-mas.yml
+++ b/.github/workflows/build-mas.yml
@@ -1,0 +1,294 @@
+name: Build & Upload Mac App Store
+
+# Trigger on push to main branch when version/build files change
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'           # App version
+      - 'forge.config.js'        # Build number
+      - '.github/workflows/build-mas.yml'  # Workflow changes
+
+  # Allow manual trigger from Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-and-upload:
+    name: Build MAS Universal & Upload
+    runs-on: macos-latest
+
+    steps:
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 1. Checkout Repository
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 2. Extract Version & Build Number
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 📋 Extract version info
+        id: version
+        run: |
+          # Extract version from package.json
+          VERSION=$(node -p "require('./package.json').version")
+          echo "app_version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Extract build number from forge.config.js
+          BUILD_NUMBER=$(grep -o "buildVersion: '[0-9]*'" forge.config.js | grep -o "[0-9]*")
+          echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "  App Version: $VERSION"
+          echo "  Build Number: $BUILD_NUMBER"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 3. Setup Node.js Environment
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 4. Install Dependencies
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 📥 Install Node dependencies
+        run: npm ci
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 5. Setup Code Signing Certificates
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 🔐 Install Apple certificates
+        env:
+          CERTIFICATE_P12_BASE64: ${{ secrets.CERTIFICATE_P12_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
+          INSTALLER_CERTIFICATE_P12_BASE64: ${{ secrets.INSTALLER_CERTIFICATE_P12_BASE64 }}
+          INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.INSTALLER_CERTIFICATE_PASSWORD }}
+        run: |
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "  Installing Code Signing Certificates"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+          # Create temporary directory for certificates
+          CERT_DIR=$(mktemp -d)
+
+          # Decode Apple Distribution certificate
+          echo "$CERTIFICATE_P12_BASE64" | base64 --decode > "$CERT_DIR/certificate.p12"
+
+          # Decode Installer certificate
+          echo "$INSTALLER_CERTIFICATE_P12_BASE64" | base64 --decode > "$CERT_DIR/installer.p12"
+
+          # Create temporary keychain
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          # Create keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificates
+          security import "$CERT_DIR/certificate.p12" \
+            -P "$CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+
+          security import "$CERT_DIR/installer.p12" \
+            -P "$INSTALLER_CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+
+          # Set keychain in search list
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
+
+          # Set partition list (allow codesign to access)
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Verify certificates are installed
+          echo ""
+          echo "✅ Installed certificates:"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+          # Clean up certificate files
+          rm -rf "$CERT_DIR"
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 6. Install Provisioning Profile
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 📱 Install provisioning profile
+        env:
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "  Installing Provisioning Profile"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+          # Create provisioning profile directory
+          PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PP_DIR"
+
+          # Decode and save provisioning profile
+          PP_PATH="$PP_DIR/embedded.provisionprofile"
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PP_PATH"
+
+          # Extract UUID from provisioning profile
+          PP_UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<< $(security cms -D -i "$PP_PATH"))
+
+          # Rename to UUID.provisionprofile (required format)
+          mv "$PP_PATH" "$PP_DIR/$PP_UUID.provisionprofile"
+
+          echo "✅ Provisioning profile installed: $PP_UUID"
+
+          # Export UUID for later use
+          echo "PROVISIONING_PROFILE_UUID=$PP_UUID" >> $GITHUB_ENV
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 7. Build Mac App Store Package
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 🏗️ Build MAS Universal
+        env:
+          CSC_NAME: ${{ secrets.CSC_NAME }}
+          CSC_INSTALLER_NAME: ${{ secrets.CSC_INSTALLER_NAME }}
+          MAS_PROVISIONING_PROFILE: ${{ env.PROVISIONING_PROFILE_UUID }}
+        run: |
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "  Building Mac App Store Universal Package"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo ""
+          echo "Environment:"
+          echo "  CSC_NAME: $CSC_NAME"
+          echo "  CSC_INSTALLER_NAME: $CSC_INSTALLER_NAME"
+          echo "  MAS_PROVISIONING_PROFILE: $MAS_PROVISIONING_PROFILE"
+          echo ""
+
+          # Run Electron Forge build for MAS
+          npm run make -- --platform=mas --arch=universal
+
+          echo ""
+          echo "✅ Build completed!"
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 8. Verify Build Output
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 🔍 Verify build artifacts
+        id: verify
+        run: |
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "  Verifying Build Artifacts"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+          # Find PKG file
+          PKG_FILE=$(find out/make/pkg -name "*.pkg" -type f | head -n 1)
+
+          if [ -z "$PKG_FILE" ]; then
+            echo "❌ Error: PKG file not found in out/make/pkg/"
+            exit 1
+          fi
+
+          echo "✅ PKG file found: $PKG_FILE"
+
+          # Get file size
+          PKG_SIZE=$(du -h "$PKG_FILE" | cut -f1)
+          echo "   Size: $PKG_SIZE"
+
+          # Verify PKG signature
+          echo ""
+          echo "Verifying PKG signature..."
+          pkgutil --check-signature "$PKG_FILE"
+
+          # Export PKG path for upload step
+          echo "pkg_path=$PKG_FILE" >> $GITHUB_OUTPUT
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 9. Upload to App Store Connect
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 📤 Upload to App Store Connect
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "  Uploading to App Store Connect"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+          # Make upload script executable
+          chmod +x scripts/upload-appstore.sh
+
+          # Run upload script with PKG file
+          ./scripts/upload-appstore.sh "${{ steps.verify.outputs.pkg_path }}"
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 10. Upload Build Artifacts (for debugging)
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 📦 Upload build artifacts
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: klever-desktop-mas-v${{ steps.version.outputs.app_version }}-build${{ steps.version.outputs.build_number }}
+          path: |
+            out/make/pkg/*.pkg
+          retention-days: 30
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 11. Cleanup
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 🧹 Cleanup
+        if: always()
+        run: |
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "  Cleaning Up"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+          # Remove keychain
+          if [ -f "$RUNNER_TEMP/app-signing.keychain-db" ]; then
+            security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" || true
+            echo "✅ Keychain removed"
+          fi
+
+          # Remove provisioning profile
+          PP_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          if [ -d "$PP_DIR" ]; then
+            rm -rf "$PP_DIR"
+            echo "✅ Provisioning profiles removed"
+          fi
+
+          # Only remove build artifacts if upload was successful
+          if [ "${{ job.status }}" == "success" ]; then
+            echo ""
+            echo "Upload successful! Removing local build artifacts..."
+            rm -rf out/
+            echo "✅ Build artifacts removed"
+          else
+            echo ""
+            echo "⚠️  Upload failed. Keeping build artifacts for debugging."
+          fi
+
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      # 12. Summary
+      # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      - name: 🎉 Build Summary
+        if: success()
+        run: |
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "  🎉 Build & Upload Successful!"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo ""
+          echo "App Version: ${{ steps.version.outputs.app_version }}"
+          echo "Build Number: ${{ steps.version.outputs.build_number }}"
+          echo ""
+          echo "Next Steps:"
+          echo "  1. Wait 5-30 minutes for App Store Connect processing"
+          echo "  2. Check status at: https://appstoreconnect.apple.com"
+          echo "  3. Select your build and submit for review"
+          echo ""
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/encode-secrets.sh
+++ b/scripts/encode-secrets.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+
+# =================================================================
+# Encode Certificates & Provisioning Profile to Base64
+# For GitHub Actions Secrets
+# =================================================================
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Helper functions
+log_info() {
+  echo -e "${BLUE}ℹ️  $1${NC}"
+}
+
+log_success() {
+  echo -e "${GREEN}✅ $1${NC}"
+}
+
+log_warning() {
+  echo -e "${YELLOW}⚠️  $1${NC}"
+}
+
+log_error() {
+  echo -e "${RED}❌ $1${NC}"
+}
+
+log_section() {
+  echo ""
+  echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo -e "${BLUE}  $1${NC}"
+  echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+  echo ""
+}
+
+# Show usage
+show_usage() {
+  cat << EOF
+Usage: $0 <certificate.p12> <installer.p12> <embedded.provisionprofile>
+
+Encode certificates and provisioning profile to Base64 for GitHub Secrets.
+
+Arguments:
+  certificate.p12             Apple Distribution certificate (.p12)
+  installer.p12               Installer certificate (.p12)
+  embedded.provisionprofile   Mac App Store provisioning profile
+
+Example:
+  $0 certificate.p12 installer.p12 embedded.provisionprofile
+
+Output:
+  - Prints Base64 encoded strings for each file
+  - Copy these to GitHub Secrets (Settings → Secrets → Actions)
+
+GitHub Secrets to create:
+  - CERTIFICATE_P12_BASE64
+  - INSTALLER_CERTIFICATE_P12_BASE64
+  - PROVISIONING_PROFILE_BASE64
+
+EOF
+  exit 1
+}
+
+# Check arguments
+if [ "$#" -ne 3 ]; then
+  log_error "Invalid number of arguments"
+  echo ""
+  show_usage
+fi
+
+CERT_FILE="$1"
+INSTALLER_FILE="$2"
+PROFILE_FILE="$3"
+
+log_section "🔐 Encoding Certificates & Provisioning Profile"
+
+# Verify files exist
+echo "Checking files..."
+MISSING_FILES=()
+
+if [ ! -f "$CERT_FILE" ]; then
+  MISSING_FILES+=("$CERT_FILE")
+fi
+
+if [ ! -f "$INSTALLER_FILE" ]; then
+  MISSING_FILES+=("$INSTALLER_FILE")
+fi
+
+if [ ! -f "$PROFILE_FILE" ]; then
+  MISSING_FILES+=("$PROFILE_FILE")
+fi
+
+if [ ${#MISSING_FILES[@]} -ne 0 ]; then
+  log_error "Missing files:"
+  for file in "${MISSING_FILES[@]}"; do
+    echo "   - $file"
+  done
+  exit 1
+fi
+
+log_success "All files found"
+echo ""
+
+# Get file sizes
+CERT_SIZE=$(du -h "$CERT_FILE" | cut -f1)
+INSTALLER_SIZE=$(du -h "$INSTALLER_FILE" | cut -f1)
+PROFILE_SIZE=$(du -h "$PROFILE_FILE" | cut -f1)
+
+echo "File sizes:"
+echo "  📄 $CERT_FILE: $CERT_SIZE"
+echo "  📄 $INSTALLER_FILE: $INSTALLER_SIZE"
+echo "  📄 $PROFILE_FILE: $PROFILE_SIZE"
+echo ""
+
+# Encode files
+log_section "🔄 Encoding to Base64"
+
+echo "Encoding files (this may take a moment)..."
+echo ""
+
+# Encode certificate
+CERT_BASE64=$(base64 -i "$CERT_FILE")
+log_success "Encoded: $CERT_FILE"
+
+# Encode installer
+INSTALLER_BASE64=$(base64 -i "$INSTALLER_FILE")
+log_success "Encoded: $INSTALLER_FILE"
+
+# Encode provisioning profile
+PROFILE_BASE64=$(base64 -i "$PROFILE_FILE")
+log_success "Encoded: $PROFILE_FILE"
+
+# Display results
+log_section "📋 GitHub Secrets Configuration"
+
+echo "Copy the following values to GitHub Secrets:"
+echo ""
+echo -e "${CYAN}Settings → Secrets and variables → Actions → New repository secret${NC}"
+echo ""
+
+# Certificate
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}Secret Name:${NC} ${YELLOW}CERTIFICATE_P12_BASE64${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo "$CERT_BASE64"
+echo ""
+
+# Installer
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}Secret Name:${NC} ${YELLOW}INSTALLER_CERTIFICATE_P12_BASE64${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo "$INSTALLER_BASE64"
+echo ""
+
+# Provisioning Profile
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}Secret Name:${NC} ${YELLOW}PROVISIONING_PROFILE_BASE64${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo "$PROFILE_BASE64"
+echo ""
+
+# Additional instructions
+log_section "📝 Additional Secrets Required"
+
+echo "Don't forget to also add these secrets:"
+echo ""
+echo -e "  ${YELLOW}CERTIFICATE_PASSWORD${NC}"
+echo "    → Password you used when exporting certificate.p12"
+echo ""
+echo -e "  ${YELLOW}INSTALLER_CERTIFICATE_PASSWORD${NC}"
+echo "    → Password you used when exporting installer.p12"
+echo ""
+echo -e "  ${YELLOW}APPLE_ID${NC}"
+echo "    → Your Apple ID email (e.g., your@email.com)"
+echo ""
+echo -e "  ${YELLOW}APPLE_APP_SPECIFIC_PASSWORD${NC}"
+echo "    → Generate at https://appleid.apple.com/account/manage"
+echo ""
+echo -e "  ${YELLOW}APPLE_TEAM_ID${NC}"
+echo "    → Find at https://developer.apple.com/account/#!/membership"
+echo ""
+echo -e "  ${YELLOW}CSC_NAME${NC}"
+echo "    → Run: security find-identity -v -p codesigning"
+echo "    → Copy 'Apple Distribution: Your Name (TEAM_ID)'"
+echo ""
+echo -e "  ${YELLOW}CSC_INSTALLER_NAME${NC}"
+echo "    → Run: security find-identity -v -p codesigning"
+echo "    → Copy '3rd Party Mac Developer Installer: Your Name (TEAM_ID)'"
+echo ""
+
+# Security warning
+log_section "🔒 Security Notice"
+
+log_warning "IMPORTANT: Delete local certificate and profile files after uploading to GitHub"
+echo ""
+echo "  Once you've added these to GitHub Secrets, you can safely delete:"
+echo "    - $CERT_FILE"
+echo "    - $INSTALLER_FILE"
+echo "    - $PROFILE_FILE"
+echo ""
+echo "  These files contain sensitive information and should not be committed to git."
+echo ""
+
+# Completion
+log_section "✅ Encoding Complete"
+
+echo "Next steps:"
+echo "  1. Copy each Base64 value above to GitHub Secrets"
+echo "  2. Add the additional secrets listed above"
+echo "  3. Delete local certificate and profile files"
+echo "  4. Test the workflow: GitHub Actions → Run workflow"
+echo ""


### PR DESCRIPTION
Add automated build and upload workflow for Mac App Store distribution:

Workflow Features:
- Automatic certificate and provisioning profile installation
- MAS universal binary build (x64 + ARM64)
- Code signing for all Electron processes
- Automatic upload to App Store Connect
- Build artifact cleanup

Files Added:
- .github/workflows/build-mas.yml - Main CI/CD workflow
- .github/GITHUB_SECRETS_SETUP.md - Secrets configuration guide
- .github/ACTIONS_README.md - Comprehensive usage documentation
- .github/QUICKSTART_CHECKLIST.md - Step-by-step setup checklist
- scripts/encode-secrets.sh - Helper script for Base64 encoding

Triggers:
- package.json version changes
- forge.config.js buildVersion changes
- Manual workflow dispatch

Required GitHub Secrets (10 total):
- Apple account: APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID
- Certificates: CSC_NAME, CSC_INSTALLER_NAME
- Certificate files: CERTIFICATE_P12_BASE64, CERTIFICATE_PASSWORD
- Installer cert: INSTALLER_CERTIFICATE_P12_BASE64, INSTALLER_CERTIFICATE_PASSWORD
- Provisioning: PROVISIONING_PROFILE_BASE64

Complete automation: Code change → Build → Sign → Upload → Cleanup