### PR TITLE
fix: Remove arch array from maker-pkg config to fix GitHub Actions build

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -100,8 +100,6 @@ module.exports = {
         install: '/Applications',
       },
       platforms: ['mas'],
-      // Universal binary includes both x64 and arm64
-      arch: ['universal'],
     },
 
     // ZIP maker for development and testing


### PR DESCRIPTION
The maker-pkg configuration had `arch: ['universal']` which was causing
the build to fail in GitHub Actions. Since the arch is already specified
via command-line argument `--arch=universal`, the maker config doesn't
need to duplicate this specification.

This fixes the "Process completed with exit code 1" error in the
"Verify build artifacts" step.