### PR TITLE
chore: Change MAS workflow to manual trigger only

### DIFF
--- a/.github/workflows/build-mas.yml
+++ b/.github/workflows/build-mas.yml
@@ -1,16 +1,7 @@
 name: Build & Upload Mac App Store
 
-# Trigger on push to main branch when version/build files change
+# Manual trigger only from GitHub Actions tab
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'package.json'           # App version
-      - 'forge.config.js'        # Build number
-      - '.github/workflows/build-mas.yml'  # Workflow changes
-
-  # Allow manual trigger from Actions tab
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Remove automatic push trigger for build-mas.yml workflow.
Now requires manual dispatch from GitHub Actions tab.

This allows better control over when Mac App Store builds
are created and uploaded.