### PR TITLE
Migrate to App Store Connect API key

### DIFF
--- a/.github/workflows/build-mas.yml
+++ b/.github/workflows/build-mas.yml
@@ -202,20 +202,26 @@ jobs:
       # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
       # 9. Upload to App Store Connect
       # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-      - name: 📤 Upload to App Store Connect
+      - name: 📤 Upload to App Store Connect (API Key)
         env:
+          # API Key authentication (modern, preferred)
+          APPSTORE_API_KEY_BASE64: ${{ secrets.APPSTORE_API_KEY_BASE64 }}
+          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          # Apple ID authentication (legacy fallback)
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "  Uploading to App Store Connect"
+          echo "  Uploading to App Store Connect (API Key Method)"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
           # Make upload script executable
           chmod +x scripts/upload-appstore.sh
 
           # Run upload script with PKG file
+          # Script will automatically prefer API Key if available
           ./scripts/upload-appstore.sh "${{ steps.verify.outputs.pkg_path }}"
 
       # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
- Replace upload-appstore.sh with API Key-based authentication
- Update build-mas.yml workflow to use API Key secrets
- Maintain Apple ID fallback for compatibility
- Resolves altool deprecation issue

Changes:
- API Key authentication (modern, preferred method)
- Automatic fallback to Apple ID if API Key not available
- Improved error messages for API Key issues
- Secure API Key handling (decode → use → cleanup)

Benefits:
- Resolves altool deprecation warnings
- More stable and reliable uploads
- Better security with JWT-based authentication
- Official Apple recommended method