### PR TITLE
Test App Store Connect API Key migration

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -38,6 +38,15 @@ module.exports = {
       'entitlements-inherit': path.resolve(__dirname, 'build/entitlements.mas.inherit.plist'),
       // Optional: Add provisioning profile if you have one
       provisioningProfile: process.env.MAS_PROVISIONING_PROFILE || undefined,
+      // Explicitly list all binaries that need signing
+      binaries: [
+        'Contents/MacOS/Klever Desktop',
+        'Contents/Frameworks/Klever Desktop Helper.app',
+        'Contents/Frameworks/Klever Desktop Helper (GPU).app',
+        'Contents/Frameworks/Klever Desktop Helper (Plugin).app',
+        'Contents/Frameworks/Klever Desktop Helper (Renderer).app',
+        'Contents/Library/LoginItems/Klever Desktop Login Helper.app',
+      ],
       // CRITICAL: Sign all Electron helper processes with inherit entitlements
       optionsForFile: (filePath) => {
         // All helper apps and Login Items must use inherit entitlements
@@ -58,9 +67,8 @@ module.exports = {
           entitlements: path.resolve(__dirname, 'build/entitlements.mas.plist'),
         };
       },
-      hardenedRuntime: true, // Enable Hardened Runtime for MAS
+      hardenedRuntime: false, // MAS doesn't need hardened runtime (notarization is not required)
       gatekeeperAssess: false, // Disable Gatekeeper assessment for MAS
-      signatureFlags: ['runtime'], // Add runtime signature flag
     }
   },
 


### PR DESCRIPTION
- Add explicit binaries list for complete signing coverage
- Remove hardened runtime requirement (not needed for MAS)
- Remove signatureFlags (notarization not required for MAS)
- Keep optionsForFile to ensure all helpers use inherit entitlements

This resolves the App Store validation error:
'App sandbox not enabled' for Electron helper executables

Technical details:
- MAS builds don't require notarization (unlike direct distribution)
- All Electron helper processes must be signed with inherit entitlements
- binaries list ensures no helper is missed during signing
- Sandbox entitlement (com.apple.security.app-sandbox) is now properly inherited