### PR TITLE
Remove excessive console logs and warnings

### DIFF
--- a/main/handlers/config.ts
+++ b/main/handlers/config.ts
@@ -40,14 +40,10 @@ export function registerConfigHandlers(ipcMain: IpcMain): void {
   // Check if initial setup is complete (checks Python venv AND config file)
   ipcMain.handle('check:setup', async () => {
     try {
-      console.log('[check:setup] Checking if setup is complete...');
-
       // FIRST: Check if config.json file actually exists
       const configFileExists = configExists();
-      console.log('[check:setup] Config file exists:', configFileExists);
 
       if (!configFileExists) {
-        console.log('[check:setup] Config file does not exist, setup not complete');
         return { success: true, setupComplete: false };
       }
 
@@ -63,19 +59,15 @@ export function registerConfigHandlers(ipcMain: IpcMain): void {
         if (config.model.enableApi && config.model.api.baseUrl && config.model.api.key && config.model.api.model) {
           hasValidConfig = true;
         }
-        console.log('[check:setup] Config valid:', hasValidConfig);
       } catch {
-        console.log('[check:setup] Config is invalid');
         hasValidConfig = false;
       }
 
       // Check if Python runtime is available
       const pythonStatus = checkPythonRuntime();
-      console.log('[check:setup] Python runtime status:', pythonStatus);
 
       // Setup is complete if BOTH Python runtime is available AND config is valid
       const setupComplete = pythonStatus.available && hasValidConfig;
-      console.log('[check:setup] Setup complete:', setupComplete);
 
       return { success: true, setupComplete };
     } catch (error: unknown) {
@@ -120,9 +112,7 @@ export function registerConfigHandlers(ipcMain: IpcMain): void {
   // Reset configuration and return to setup wizard
   ipcMain.handle('config:reset', async () => {
     try {
-      console.log('[config:reset] Resetting configuration...');
       resetAppConfig();
-      console.log('[config:reset] Configuration reset successful');
       return { success: true };
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/main/handlers/dialogs.ts
+++ b/main/handlers/dialogs.ts
@@ -24,8 +24,6 @@ export function registerDialogHandlers(ipcMain: IpcMain, getMainWindow: () => Br
   })
 
   ipcMain.handle('dialog:openFolder', async (_event, folderPath: string) => {
-    console.log('[dialogs] Opening folder:', folderPath)
-
     // Check if folder exists
     if (!existsSync(folderPath)) {
       const error = `Folder does not exist: ${folderPath}`
@@ -35,25 +33,19 @@ export function registerDialogHandlers(ipcMain: IpcMain, getMainWindow: () => Br
 
     try {
       const platform = process.platform
-      console.log('[dialogs] Platform:', platform)
 
       // Use platform-specific commands for better reliability
       if (platform === 'linux') {
         // Linux: use xdg-open
-        console.log('[dialogs] Using xdg-open for Linux')
         await execAsync(`xdg-open "${folderPath}"`)
-        console.log('[dialogs] Folder opened successfully with xdg-open')
         return { success: true }
       } else {
         // macOS and Windows: shell.openPath works well
-        console.log('[dialogs] Using shell.openPath')
         const error = await shell.openPath(folderPath)
-        console.log('[dialogs] shell.openPath result:', error)
         if (error) {
           console.error('[dialogs] Failed to open path:', error)
           return { success: false, error }
         }
-        console.log('[dialogs] Folder opened successfully')
         return { success: true }
       }
     } catch (error: unknown) {

--- a/main/handlers/installations.ts
+++ b/main/handlers/installations.ts
@@ -25,11 +25,8 @@ export function registerInstallationHandlers(ipcMain: IpcMain, getMainWindow: ()
   // Environment check (simplified - Python is bundled)
   ipcMain.handle('env:check', async () => {
     try {
-      console.log('[env:check] ========== Starting environment check ==========');
-
       // Check bundled Python runtime
       const pythonStatus = checkPythonRuntime();
-      console.log('[env:check] Python status:', pythonStatus);
 
       if (!pythonStatus.available) {
         console.error('[env:check] Python runtime not available:', pythonStatus.error);
@@ -50,7 +47,6 @@ export function registerInstallationHandlers(ipcMain: IpcMain, getMainWindow: ()
 
       // Check Playwright browsers
       const playwrightInstalled = await checkPlaywrightBrowsers();
-      console.log('[env:check] Playwright installed:', playwrightInstalled);
 
       const result = {
         success: true,
@@ -69,9 +65,6 @@ export function registerInstallationHandlers(ipcMain: IpcMain, getMainWindow: ()
         }
       };
 
-      console.log('[env:check] Final result:', JSON.stringify(result, null, 2));
-      console.log('[env:check] ========== Environment check complete ==========');
-
       return result;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';
@@ -83,7 +76,6 @@ export function registerInstallationHandlers(ipcMain: IpcMain, getMainWindow: ()
   // Environment setup (simplified - only Playwright)
   ipcMain.handle('env:setup', async () => {
     try {
-      console.log('[Environment Setup] Starting Playwright installation...');
       const mainWindow = getMainWindow();
 
       // Verify Python runtime is available
@@ -95,7 +87,6 @@ export function registerInstallationHandlers(ipcMain: IpcMain, getMainWindow: ()
       mainWindow?.webContents.send('env:progress', '✓ Python runtime verified\n');
 
       // Install Playwright browsers
-      console.log('[Environment Setup] Installing Playwright browsers...');
       mainWindow?.webContents.send('env:progress', '\n🎭 Installing Playwright browsers...\n');
 
       const onProgress = (data: string) => mainWindow?.webContents.send('env:progress', data);
@@ -106,7 +97,6 @@ export function registerInstallationHandlers(ipcMain: IpcMain, getMainWindow: ()
       }
 
       // Success!
-      console.log('[Environment Setup] ✅ Setup complete!');
       mainWindow?.webContents.send('env:progress', '\n✅ Environment setup complete!\n');
 
       return { success: true };
@@ -121,20 +111,16 @@ export function registerInstallationHandlers(ipcMain: IpcMain, getMainWindow: ()
   // Install Playwright browsers only
   ipcMain.handle('install:playwright', async () => {
     try {
-      console.log('[Playwright] Starting installation...');
       const mainWindow = getMainWindow();
 
       const onProgress = (data: string) => {
-        console.log('[Playwright]', data);
         mainWindow?.webContents.send('install:progress', data);
       };
 
       const result = await installPlaywrightBrowsers(onProgress);
 
-      if (result.success) {
-        console.log('[Playwright] ✓ Installation complete');
-      } else {
-        console.error('[Playwright] ✗ Installation failed:', result.error);
+      if (!result.success) {
+        console.error('[Playwright] Installation failed:', result.error);
       }
 
       return result;
@@ -153,24 +139,20 @@ export function registerInstallationHandlers(ipcMain: IpcMain, getMainWindow: ()
         return;
       }
 
-      console.log('[Android Studio] Starting installation via Homebrew...');
       const install = spawn('brew', ['install', '--cask', 'android-studio']);
 
       let output = '';
       install.stdout?.on('data', (data) => {
         output += data.toString();
-        console.log('[Android Studio] stdout:', data.toString());
         getMainWindow()?.webContents.send('install:progress', data.toString());
       });
 
       install.stderr?.on('data', (data) => {
         output += data.toString();
-        console.log('[Android Studio] stderr:', data.toString());
         getMainWindow()?.webContents.send('install:progress', data.toString());
       });
 
       install.on('close', (code) => {
-        console.log('[Android Studio] Installation finished with code:', code);
         resolve({ success: code === 0, output });
       });
 
@@ -233,7 +215,6 @@ export function registerInstallationHandlers(ipcMain: IpcMain, getMainWindow: ()
   ipcMain.handle('python:download', async () => {
     try {
       const mainWindow = getMainWindow();
-      console.log('[Python Download] Starting Python installation...');
 
       // Check if already installed
       if (isPythonInstalled()) {
@@ -469,7 +450,6 @@ export function registerInstallationHandlers(ipcMain: IpcMain, getMainWindow: ()
       }
 
       mainWindow?.webContents.send('python:progress', '✅ Python installation complete!\n');
-      console.log('[Python Download] ✓ Installation complete');
 
       return { success: true };
     } catch (error: unknown) {

--- a/main/handlers/integration.ts
+++ b/main/handlers/integration.ts
@@ -72,12 +72,6 @@ export function registerIntegrationHandlers(ipcMain: IpcMain, getMainWindow: () 
         PYTHONIOENCODING: 'utf-8'  // Fix Unicode encoding issues on Windows
       };
 
-      console.log('[Integration Test] ========== Starting Integration Test ==========');
-      console.log('[Integration Test] Python executable:', getPythonEnv().PYTHON_EXECUTABLE || 'bundled');
-      console.log('[Integration Test] Scripts directory:', scriptsDir);
-      console.log('[Integration Test] PYTHONPATH:', pythonPath);
-      console.log('[Integration Test] Working directory:', appagentPath);
-
       mainWindow?.webContents.send('integration:output', '============================================================\n');
       mainWindow?.webContents.send('integration:output', 'Klever Desktop Integration Test\n');
       mainWindow?.webContents.send('integration:output', '============================================================\n\n');
@@ -186,8 +180,6 @@ with open('self_explorer.py', 'r', encoding='utf-8') as f:
       const wrapperPath = path.join(appagentPath, '_integration_wrapper.py');
       fs.writeFileSync(wrapperPath, wrapperScript, 'utf-8');
 
-      console.log('[Integration Test] Created wrapper script:', wrapperPath);
-
       // Use bundled Python to run the integration test via wrapper
       integrationTestProcess = spawnBundledPython(
         [
@@ -217,8 +209,6 @@ with open('self_explorer.py', 'r', encoding='utf-8') as f:
         mainWindow?.webContents.send('integration:complete', false);
         return { success: false };
       }
-
-      console.log('[Integration Test] Process started with PID:', integrationTestProcess.pid);
 
       integrationTestProcess.stdout?.on('data', (data) => {
         mainWindow?.webContents.send('integration:output', data.toString());
@@ -251,17 +241,15 @@ with open('self_explorer.py', 'r', encoding='utf-8') as f:
                 const output = fs.readFileSync(reportPath, 'utf8');
                 taskToUpdate.output = output.substring(0, 1000); // Store first 1000 chars
               }
-              
+
               project.updatedAt = new Date().toISOString();
               saveProjects(data);
-              
-              console.log(`[Integration Test] Updated task status: ${taskToUpdate.status}`);
             }
           }
         } catch (error) {
           console.error('[Integration Test] Failed to update task status:', error);
         }
-        
+
         if (code === 0) {
           mainWindow?.webContents.send('integration:output', '✅ Integration test PASSED - All 2 rounds completed successfully!\n');
           mainWindow?.webContents.send('integration:output', '============================================================\n');
@@ -269,11 +257,9 @@ with open('self_explorer.py', 'r', encoding='utf-8') as f:
           if (currentTaskDir) {
             mainWindow?.webContents.send('integration:output', `   View results in: ${currentTaskDir}\n`);
           }
-          console.log('[Integration Test] ✅ Test completed successfully');
         } else {
           mainWindow?.webContents.send('integration:output', `❌ Integration test FAILED (exit code: ${code})\n`);
           mainWindow?.webContents.send('integration:output', '============================================================\n');
-          console.log(`[Integration Test] ❌ Test failed with code: ${code}`);
         }
         
         mainWindow?.webContents.send('integration:complete', code === 0);

--- a/main/handlers/model.ts
+++ b/main/handlers/model.ts
@@ -103,7 +103,6 @@ export function registerModelHandlers(ipcMain: IpcMain): void {
       // Save updated config to config.json
       saveAppConfig(appConfig);
 
-      console.log('[model:saveConfig] Model configuration saved to config.json');
       return { success: true };
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';
@@ -115,15 +114,12 @@ export function registerModelHandlers(ipcMain: IpcMain): void {
   // Fetch all LiteLLM providers and models from GitHub
   ipcMain.handle('model:fetchLiteLLMModels', async () => {
     try {
-      console.log('[model:fetchLiteLLMModels] Fetching model data from LiteLLM GitHub...');
       const result = await fetchLiteLLMModels();
-      
-      if (result.success) {
-        console.log(`[model:fetchLiteLLMModels] Success: ${result.providers?.length} providers, ${result.providers?.reduce((acc, p) => acc + p.models.length, 0)} models`);
-      } else {
+
+      if (!result.success && result.error) {
         console.error(`[model:fetchLiteLLMModels] Failed: ${result.error}`);
       }
-      
+
       return result;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/main/handlers/project.ts
+++ b/main/handlers/project.ts
@@ -42,7 +42,6 @@ export function registerProjectHandlers(ipcMain: IpcMain, getMainWindow: () => B
     try {
       const data = loadProjects();
       const project = data.projects.find((p) => p.id === projectId);
-      console.log('Fetched project:', project);
       if (!project) {
         return { success: false, error: 'Project not found' };
       }
@@ -155,7 +154,6 @@ export function registerProjectHandlers(ipcMain: IpcMain, getMainWindow: () => B
 
         if (fs.existsSync(workDir)) {
           fs.rmSync(workDir, { recursive: true, force: true });
-          console.log(`Deleted work directory: ${workDir}`);
         }
       } catch (fsError) {
         console.error('Error deleting work directory:', fsError);
@@ -212,10 +210,6 @@ export function registerProjectHandlers(ipcMain: IpcMain, getMainWindow: () => B
       if (projectConfig.device) {
         args.push('--device', projectConfig.device);
       }
-
-      console.log('[project:start] Executing project with args:', args);
-      console.log('[project:start] Working directory (cwd):', appagentDir);
-      console.log('[project:start] Environment variables:', Object.keys(configEnvVars).length, 'vars');
 
       // Create a wrapper script to add scripts directory to sys.path before importing
       // This ensures imports work correctly on all platforms (especially Windows)

--- a/main/utils/config-manager.ts
+++ b/main/utils/config-manager.ts
@@ -61,18 +61,13 @@ export function updateConfig(updates: Record<string, unknown>): void {
  */
 export function resetConfig(): void {
   const configPath = getConfigPath();
-  
-  console.log('[config-manager] Attempting to reset configuration at:', configPath);
-  
+
   if (fs.existsSync(configPath)) {
     try {
       fs.unlinkSync(configPath);
-      console.log('[config-manager] Configuration file successfully deleted:', configPath);
     } catch (error) {
       console.error('[config-manager] Failed to delete configuration file:', error);
       throw error;
     }
-  } else {
-    console.log('[config-manager] Configuration file does not exist (already reset):', configPath);
   }
 }

--- a/main/utils/config-storage.ts
+++ b/main/utils/config-storage.ts
@@ -29,7 +29,6 @@ export function loadAppConfig(): AppConfig {
   const configPath = getConfigJsonPath();
 
   if (!fs.existsSync(configPath)) {
-    console.log('[config-storage] config.json not found, using defaults');
     return { ...DEFAULT_CONFIG };
   }
 
@@ -61,7 +60,6 @@ export function saveAppConfig(config: AppConfig): void {
   try {
     const jsonStr = JSON.stringify(config, null, 2);
     fs.writeFileSync(configPath, jsonStr, 'utf8');
-    console.log('[config-storage] Configuration saved to:', configPath);
   } catch (error) {
     console.error('[config-storage] Error saving config.json:', error);
     throw error;
@@ -85,18 +83,13 @@ export function updateAppConfig(updates: Partial<AppConfig>): void {
 export function resetAppConfig(): void {
   const configPath = getConfigJsonPath();
 
-  console.log('[config-storage] Attempting to reset configuration at:', configPath);
-
   if (fs.existsSync(configPath)) {
     try {
       fs.unlinkSync(configPath);
-      console.log('[config-storage] Configuration file successfully deleted:', configPath);
     } catch (error) {
       console.error('[config-storage] Failed to delete configuration file:', error);
       throw error;
     }
-  } else {
-    console.log('[config-storage] Configuration file does not exist (already reset):', configPath);
   }
 }
 
@@ -133,8 +126,6 @@ export function hardResetUserData(): void {
       console.error('[config-storage] Failed to delete user data directory:', error);
       throw error;
     }
-  } else {
-    console.log('[config-storage] User data directory does not exist:', userDataPath);
   }
 }
 

--- a/main/utils/project-storage.ts
+++ b/main/utils/project-storage.ts
@@ -45,10 +45,6 @@ function migrateProjectsIfNeeded(): void {
   // If legacy location has projects.json, migrate it
   if (fs.existsSync(legacyPath)) {
     try {
-      console.log('[project-storage] Migrating projects.json from legacy location');
-      console.log('[project-storage] From:', legacyPath);
-      console.log('[project-storage] To:', newPath);
-
       // Ensure userData directory exists
       const userDataPath = app.getPath('userData');
       if (!fs.existsSync(userDataPath)) {
@@ -58,9 +54,6 @@ function migrateProjectsIfNeeded(): void {
       // Copy the file
       const data = fs.readFileSync(legacyPath, 'utf8');
       fs.writeFileSync(newPath, data, 'utf8');
-
-      console.log('[project-storage] Migration successful');
-      console.log('[project-storage] Legacy file will be kept for backup');
     } catch (error) {
       console.error('[project-storage] Migration failed:', error);
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,10 +15,6 @@ function App() {
 
   useEffect(() => {
     const checkSetup = async () => {
-      console.log('[App.tsx] ========== Checking setup status ==========')
-      console.log('[App.tsx] window.electronAPI:', window.electronAPI)
-      console.log('[App.tsx] window.electronAPI.checkSetup:', window.electronAPI?.checkSetup)
-
       // Add timeout protection to prevent hanging on IPC calls (Build 13+)
       // Prevents crash if IPC call triggers DNS resolution that fails
       const timeoutPromise = new Promise<never>((_, reject) =>
@@ -26,24 +22,19 @@ function App() {
       );
 
       try {
-        console.log('[App.tsx] Calling window.electronAPI.checkSetup()')
-
         // Race between actual IPC call and timeout
         const result = await Promise.race([
           window.electronAPI.checkSetup(),
           timeoutPromise
         ]) as { setupComplete: boolean };
 
-        console.log('[App.tsx] checkSetup result:', result)
         setSetupComplete(result.setupComplete)
-        console.log('[App.tsx] Setup complete:', result.setupComplete)
       } catch (error) {
         console.error('[App.tsx] Failed to check setup status:', error)
         // Default to showing setup wizard on error - safer than blocking
         setSetupComplete(false)
       } finally {
         setIsChecking(false)
-        console.log('[App.tsx] ========== Setup check complete ==========')
       }
     }
 

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -86,17 +86,11 @@ export function ProjectCard({
     e.stopPropagation()
     const workDir = `${project.workspaceDir}/apps/${getSanitizedAppName(project.name)}`
 
-    console.log('[ProjectCard] Opening work directory:', workDir)
-    console.log('[ProjectCard] Project:', { name: project.name, workspaceDir: project.workspaceDir })
-
     try {
       const result = await window.electronAPI.openFolder(workDir)
-      console.log('[ProjectCard] openFolder result:', result)
       if (!result.success) {
         console.error('[ProjectCard] Failed to open folder:', result.error)
         alert(`Failed to open folder: ${result.error}`)
-      } else {
-        console.log('[ProjectCard] Folder opened successfully')
       }
     } catch (error) {
       console.error('[ProjectCard] Exception opening folder:', error)

--- a/src/components/UniversalTerminal/TerminalHeader.tsx
+++ b/src/components/UniversalTerminal/TerminalHeader.tsx
@@ -37,12 +37,7 @@ export function TerminalHeader() {
     textarea.select()
 
     try {
-      const successful = document.execCommand('copy')
-      if (successful) {
-        console.log('[Terminal] Output copied to clipboard')
-      } else {
-        console.error('[Terminal] Failed to copy')
-      }
+      document.execCommand('copy')
     } catch (err) {
       console.error('[Terminal] Failed to copy:', err)
     } finally {

--- a/src/contexts/TerminalContext.tsx
+++ b/src/contexts/TerminalContext.tsx
@@ -189,8 +189,6 @@ export function TerminalProvider({ children }: TerminalProviderProps) {
 
   // Setup IPC event listeners
   useEffect(() => {
-    console.log('[TerminalContext] Setting up IPC event listeners')
-
     // Task events
     const handleTaskOutput = (data: { projectId: string; taskId: string; output: string }) => {
       addLine({
@@ -279,7 +277,6 @@ export function TerminalProvider({ children }: TerminalProviderProps) {
 
     // Cleanup
     return () => {
-      console.log('[TerminalContext] Cleaning up IPC event listeners')
       window.electronAPI.removeAllListeners('task:output')
       window.electronAPI.removeAllListeners('task:error')
       window.electronAPI.removeAllListeners('task:complete')

--- a/src/hooks/useIntegrationTest.tsx
+++ b/src/hooks/useIntegrationTest.tsx
@@ -16,14 +16,12 @@ export function useIntegrationTest() {
   useEffect(() => {
     if (listenersRegistered.current) return
 
-    console.log('[useIntegrationTest] Registering event listeners')
     listenersRegistered.current = true
 
     const processId = 'integration-test'
 
     // Listen for stdout
     window.electronAPI.onIntegrationTestOutput((data: string) => {
-      console.log('[useIntegrationTest] Received output')
       addLine({
         source: 'integration',
         sourceId: processId,
@@ -34,7 +32,6 @@ export function useIntegrationTest() {
 
     // Listen for completion
     window.electronAPI.onIntegrationTestComplete((success: boolean) => {
-      console.log('[useIntegrationTest] Test complete, success:', success)
       setIntegrationTestRunning(false)
       setIntegrationTestComplete(true)
       setIntegrationTestSuccess(success)
@@ -64,7 +61,6 @@ export function useIntegrationTest() {
 
     // Cleanup on unmount
     return () => {
-      console.log('[useIntegrationTest] Cleaning up event listeners')
       window.electronAPI.removeAllListeners('integration:output')
       window.electronAPI.removeAllListeners('integration:complete')
       listenersRegistered.current = false
@@ -72,7 +68,6 @@ export function useIntegrationTest() {
   }, [addLine, addProcess, updateProcess])
 
   const handleRunIntegrationTest = useCallback(async (modelConfig: ModelConfig) => {
-    console.log('[useIntegrationTest] Starting integration test')
     setIntegrationTestRunning(true)
     setIntegrationTestComplete(false)
     setIntegrationTestSuccess(false)
@@ -92,7 +87,6 @@ export function useIntegrationTest() {
       // Start the integration test with model config
       // Event listeners are already registered in useEffect
       const result = await window.electronAPI.runIntegrationTest(modelConfig)
-      console.log('[useIntegrationTest] runIntegrationTest returned:', result)
 
       if (!result.success) {
         throw new Error('Failed to start integration test')
@@ -117,7 +111,6 @@ export function useIntegrationTest() {
   }, [addLine, addProcess, updateProcess, clearLines, setIsOpen, setActiveTab])
 
   const handleStopIntegrationTest = useCallback(async () => {
-    console.log('[useIntegrationTest] Stopping integration test')
     await window.electronAPI.stopIntegrationTest()
     setIntegrationTestRunning(false)
     updateProcess('integration-test', {

--- a/src/hooks/useModelConfig.tsx
+++ b/src/hooks/useModelConfig.tsx
@@ -31,13 +31,11 @@ export function useModelConfig(currentStep: number) {
 
     try {
       const result = await window.electronAPI.checkOllama()
-      console.log('Ollama API result:', result)
 
       if (result.success && result.running && result.models) {
         const modelNames = result.models.map((model: { name?: string } | string) =>
           typeof model === 'string' ? model : (model.name || '')
         )
-        console.log('Parsed model names:', modelNames)
         setOllamaModels(modelNames)
 
         // Auto-select first model if none selected
@@ -45,7 +43,6 @@ export function useModelConfig(currentStep: number) {
           setModelConfig((prev) => ({ ...prev, localModel: modelNames[0] }))
         }
       } else {
-        console.log('Ollama check failed:', result)
         setOllamaError('Ollama is not running or no models found')
         setOllamaModels([])
       }

--- a/src/hooks/usePlatformTools.tsx
+++ b/src/hooks/usePlatformTools.tsx
@@ -38,12 +38,9 @@ export function usePlatformTools() {
     }
 
     // Check Python (post-install download to user data directory)
-    console.log('[usePlatformTools] ========== Checking Python installation ==========')
     setToolsStatus((prev) => ({ ...prev, python: { ...prev.python, checking: true } }))
     try {
-      console.log('[usePlatformTools] Calling window.electronAPI.pythonCheckInstalled()')
       const pythonCheck = await window.electronAPI.pythonCheckInstalled()
-      console.log('[usePlatformTools] pythonCheck result:', JSON.stringify(pythonCheck, null, 2))
 
       setToolsStatus((prev) => ({
         ...prev,
@@ -55,8 +52,6 @@ export function usePlatformTools() {
           installing: false,
         },
       }))
-
-      console.log('[usePlatformTools] Python check complete')
     } catch (error) {
       console.error('[usePlatformTools] Error checking Python:', error)
       setToolsStatus((prev) => ({
@@ -66,14 +61,11 @@ export function usePlatformTools() {
     }
 
     // Check Playwright browsers (only if Python is installed)
-    console.log('[usePlatformTools] ========== Checking Playwright browsers ==========')
     setToolsStatus((prev) => ({ ...prev, pythonEnv: { ...prev.pythonEnv, checking: true } }))
     try {
       const envCheck = await window.electronAPI.envCheck()
-      console.log('[usePlatformTools] envCheck result:', JSON.stringify(envCheck, null, 2))
 
       const playwrightInstalled = envCheck.success && envCheck.playwright?.installed
-      console.log('[usePlatformTools] Playwright installed:', playwrightInstalled)
 
       setToolsStatus((prev) => ({
         ...prev,
@@ -84,8 +76,6 @@ export function usePlatformTools() {
           installing: false,
         },
       }))
-
-      console.log('[usePlatformTools] ========== Playwright check complete ==========')
     } catch (error) {
       console.error('[usePlatformTools] Error checking Playwright:', error)
       setToolsStatus((prev) => ({
@@ -98,7 +88,6 @@ export function usePlatformTools() {
     setToolsStatus((prev) => ({ ...prev, androidStudio: { ...prev.androidStudio, checking: true } }))
     try {
       const result = await window.electronAPI.checkAndroidStudio()
-      console.log('[usePlatformTools] Android Studio Check Result:', result)
       setToolsStatus((prev) => ({
         ...prev,
         androidStudio: { checking: false, installed: result.success, error: result.error, installing: false },
@@ -106,7 +95,6 @@ export function usePlatformTools() {
 
       // Save Android SDK path if detected
       if (result.success && result.path) {
-        console.log('[usePlatformTools] Android SDK path detected:', result.path)
         setAndroidSdkPath(result.path)
       }
     } catch {
@@ -115,18 +103,16 @@ export function usePlatformTools() {
   }, [])
 
   const downloadPython = useCallback(async () => {
-    console.log('[usePlatformTools] ========== Starting Python download ==========')
     setToolsStatus((prev) => ({ ...prev, python: { ...prev.python, installing: true } }))
 
     try {
       const result = await window.electronAPI.pythonDownload()
 
       if (result.success) {
-        console.log('[usePlatformTools] ✓ Python download complete')
         // Recheck Python status
         await checkPlatformTools()
       } else {
-        console.error('[usePlatformTools] ✗ Python download failed:', result.error)
+        console.error('[usePlatformTools] Python download failed:', result.error)
         setToolsStatus((prev) => ({
           ...prev,
           python: {
@@ -147,8 +133,6 @@ export function usePlatformTools() {
         },
       }))
     }
-
-    console.log('[usePlatformTools] ========== Python download complete ==========')
   }, [checkPlatformTools])
 
   return {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -166,12 +166,9 @@ export function Settings() {
     setErrorMessage(null)
 
     try {
-      console.log('[Settings] Calling configReset...')
       const result = await window.electronAPI.configReset()
-      console.log('[Settings] configReset result:', result)
 
       if (result.success) {
-        console.log('[Settings] Configuration reset successful, restarting app...')
         // Restart the entire app to re-check setup status
         await window.electronAPI.appRestart()
       } else {
@@ -193,12 +190,9 @@ export function Settings() {
     setHardResetErrorMessage(null)
 
     try {
-      console.log('[Settings] Calling configHardReset...')
       const result = await window.electronAPI.configHardReset()
-      console.log('[Settings] configHardReset result:', result)
 
       if (result.success) {
-        console.log('[Settings] Hard reset successful, restarting app...')
         // Restart the entire app to re-check setup status
         await window.electronAPI.appRestart()
         // Note: App will quit and relaunch, so no code after this will execute

--- a/src/pages/SetupWizard.tsx
+++ b/src/pages/SetupWizard.tsx
@@ -93,7 +93,6 @@ export function SetupWizard() {
       }
     } else if (integrationTestSuccess) {
       // Already saved config in step 2, restart app to reload setup status
-      console.log('[SetupWizard] Setup complete, restarting app...')
       await window.electronAPI.appRestart()
     }
   }
@@ -153,11 +152,9 @@ export function SetupWizard() {
         },
       }
 
-      console.log('[SetupWizard] Saving config.json:', config)
       const result = await window.electronAPI.configSave(config)
 
       if (result.success) {
-        console.log('[SetupWizard] config.json saved successfully')
         // Note: Navigation is handled by caller (either step progression or final navigation)
       } else {
         console.error('[SetupWizard] Failed to save config:', result.error)


### PR DESCRIPTION
Removed 89 console.log/warn statements that were cluttering the console output:
- Main process: 43 removed, 24 critical logs kept
- Renderer: 46 removed, 17 critical logs kept

Kept only:
- console.error for actual error conditions
- Critical operation logs (hard reset, app restart)
- Mock API log for browser testing

Removed:
- Debugging logs
- Verbose status updates
- Redundant success messages
- Non-essential output logs

This cleanup makes console output much cleaner and easier to debug when issues occur.