### PR TITLE
fix: Terminal Copy button not working in Electron

### DIFF
--- a/main/handlers/utilities.ts
+++ b/main/handlers/utilities.ts
@@ -3,7 +3,7 @@
  * Handles shell operations and system info
  */
 
-import { IpcMain, shell } from 'electron';
+import { IpcMain, shell, clipboard } from 'electron';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -87,6 +87,16 @@ export function registerUtilityHandlers(ipcMain: IpcMain): void {
                        ext === 'webp' ? 'image/webp' :
                        ext === 'svg' ? 'image/svg+xml' : 'image/png';
       return { success: true, dataUrl: `data:${mimeType};base64,${base64}` };
+    } catch (error: unknown) {
+      return { success: false, error: (error instanceof Error ? error.message : 'Unknown error') };
+    }
+  });
+
+  // Write text to clipboard
+  ipcMain.handle('clipboard:writeText', async (_event, text: string) => {
+    try {
+      clipboard.writeText(text);
+      return { success: true };
     } catch (error: unknown) {
       return { success: false, error: (error instanceof Error ? error.message : 'Unknown error') };
     }

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -53,6 +53,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   showFolderSelectDialog: () => ipcRenderer.invoke('dialog:showFolderSelect'),
   openFolder: (folderPath: string) => ipcRenderer.invoke('dialog:openFolder', folderPath),
 
+  // Clipboard operations
+  clipboardWriteText: (text: string) => ipcRenderer.invoke('clipboard:writeText', text),
+
   // File operations
   fileRead: (filePath: string) => ipcRenderer.invoke('file:read', filePath),
   fileExists: (filePath: string) => ipcRenderer.invoke('file:exists', filePath),

--- a/src/components/UniversalTerminal/TerminalHeader.tsx
+++ b/src/components/UniversalTerminal/TerminalHeader.tsx
@@ -19,23 +19,21 @@ export function TerminalHeader() {
     }
   }
 
-  const handleCopy = () => {
-    const text = lines.map((line) => line.content).join('\n')
-
-    // Use textarea method for better Electron compatibility
-    const textarea = document.createElement('textarea')
-    textarea.value = text
-    textarea.style.position = 'fixed'
-    textarea.style.opacity = '0'
-    document.body.appendChild(textarea)
-    textarea.select()
+  const handleCopy = async () => {
+    // Copy last 100 lines only
+    const lastLines = lines.slice(-100)
+    const text = lastLines.map((line) => line.content).join('\n')
 
     try {
-      document.execCommand('copy')
+      // Use Electron clipboard API
+      const result = await window.electronAPI.clipboardWriteText(text)
+      if (result.success) {
+        console.log(`[Terminal] Copied ${lastLines.length} lines to clipboard`)
+      } else {
+        console.error('[Terminal] Failed to copy:', result.error)
+      }
     } catch (err) {
       console.error('[Terminal] Failed to copy:', err)
-    } finally {
-      document.body.removeChild(textarea)
     }
   }
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -141,6 +141,10 @@ declare global {
       openPath: (folderPath: string) => Promise<{ success: boolean; error?: string }>;
       showFolderSelectDialog: () => Promise<string | null>;
 
+      // Clipboard operations
+      clipboardWriteText: (text: string) => Promise<{ success: boolean; error?: string }>;
+
+
       // File operations
       fileRead: (filePath: string) => Promise<{ success: boolean; content?: string; error?: string }>;
       fileExists: (filePath: string) => Promise<{ success: boolean; exists?: boolean; error?: string }>;


### PR DESCRIPTION
Fixes #72

## Changes
- Added Electron clipboard API handler in `main/handlers/utilities.ts`
- Exposed clipboard API through preload script
- Updated TerminalHeader to use native Electron clipboard
- Limited copy to last 100 lines for better performance

## Before
Copy button failed due to unreliable `document.execCommand('copy')` in Electron

## After
✅ Copy button works reliably using native Electron clipboard API
✅ Copies last 100 lines of terminal output