### PR TITLE
feat: Add AppAgent sync script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint:fix": "eslint . --ext .ts,.tsx,.js,.jsx --fix",
     "python:verify": "node scripts/verify-bundle.js",
     "python:sync": "node scripts/python-sync.js",
-    "python:sync:all": "node scripts/python-refresh.js"
+    "python:sync:all": "node scripts/python-refresh.js",
+    "appagent:sync": "node scripts/appagent-sync.js"
   },
   "keywords": [
     "electron",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,97 @@
+# Scripts
+
+This directory contains utility scripts for the Klever Desktop project.
+
+## appagent-sync.js
+
+Synchronizes changes from the local `appagent/` folder to the original [AppAgent repository](https://github.com/FigmaAI/AppAgent).
+
+### Usage
+
+**Interactive mode** (prompts for commit message):
+```bash
+npm run appagent:sync
+```
+
+**With commit message as argument**:
+```bash
+npm run appagent:sync -- --message "fix: update llm_service.py"
+# or
+npm run appagent:sync -- -m "feat: add new feature"
+```
+
+### How it works
+
+1. Checks if git is installed
+2. Creates a temporary directory
+3. Clones the AppAgent repository
+4. Copies `appagent/` folder contents (excluding `.git`, `__pycache__`, etc.)
+5. Checks for changes with `git status`
+6. If changes exist:
+   - Prompts for commit message (if not provided)
+   - Stages all changes
+   - Creates a commit
+   - Pushes to `origin/main`
+7. Cleans up temporary directory
+
+### Excluded files/directories
+
+The following patterns are excluded from sync:
+- `.git`
+- `__pycache__`
+- `*.pyc`
+- `.DS_Store`
+- `.pytest_cache`
+- `*.egg-info`
+- `node_modules`
+- `.venv`
+- `venv`
+
+### Requirements
+
+- Git must be installed and configured with credentials
+- Write access to the AppAgent repository
+- Git credentials (SSH key or credential helper) must be configured
+
+### Error handling
+
+- If git is not installed, the script will exit with instructions
+- If no changes are detected, the script will exit gracefully
+- If the push fails (e.g., network error, permission denied), the script will show the error
+- Temporary directory is always cleaned up, even on errors
+
+---
+
+## python-sync.js
+
+Synchronizes Python dependencies by installing packages from `appagent/requirements.txt` into the virtual environment.
+
+### Usage
+
+```bash
+npm run python:sync
+```
+
+---
+
+## python-refresh.js
+
+Recreates the Python virtual environment and installs all dependencies from scratch.
+
+### Usage
+
+```bash
+npm run python:sync:all
+```
+
+---
+
+## verify-bundle.js
+
+Verifies that all required files are properly bundled in the production build.
+
+### Usage
+
+```bash
+npm run python:verify
+```

--- a/scripts/appagent-sync.js
+++ b/scripts/appagent-sync.js
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const fs = require('fs');
+const { execSync, spawn } = require('child_process');
+const os = require('os');
+const readline = require('readline');
+
+const REPO_URL = 'https://github.com/FigmaAI/AppAgent.git';
+const APPAGENT_SOURCE = path.join(__dirname, '..', 'appagent');
+
+// Files and directories to exclude from sync
+const EXCLUDE_PATTERNS = [
+  '.git',
+  '__pycache__',
+  '*.pyc',
+  '.DS_Store',
+  '.pytest_cache',
+  '*.egg-info',
+  'node_modules',
+  '.venv',
+  'venv'
+];
+
+// ANSI color codes
+const colors = {
+  reset: '\x1b[0m',
+  bright: '\x1b[1m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m'
+};
+
+function log(message, color = 'reset') {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function checkGitInstalled() {
+  try {
+    execSync('git --version', { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    log('Error: git is not installed or not in PATH', 'red');
+    log('Please install git: https://git-scm.com/downloads', 'yellow');
+    return false;
+  }
+}
+
+function shouldExclude(filename) {
+  return EXCLUDE_PATTERNS.some(pattern => {
+    if (pattern.includes('*')) {
+      const regex = new RegExp(pattern.replace('*', '.*'));
+      return regex.test(filename);
+    }
+    return filename === pattern;
+  });
+}
+
+function copyDirectory(src, dest) {
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (shouldExclude(entry.name)) {
+      continue;
+    }
+
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      fs.mkdirSync(destPath, { recursive: true });
+      copyDirectory(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: options.silent ? 'pipe' : 'inherit',
+      cwd: options.cwd,
+      ...options
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    if (options.silent) {
+      child.stdout?.on('data', (data) => {
+        stdout += data.toString();
+      });
+      child.stderr?.on('data', (data) => {
+        stderr += data.toString();
+      });
+    }
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(new Error(`Command failed with code ${code}: ${stderr || stdout}`));
+      }
+    });
+
+    child.on('error', reject);
+  });
+}
+
+async function promptCommitMessage() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  return new Promise((resolve) => {
+    rl.question('Enter commit message: ', (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function main() {
+  log('\n🔄 AppAgent Sync Script', 'bright');
+  log('━'.repeat(50), 'cyan');
+
+  // Check if git is installed
+  if (!checkGitInstalled()) {
+    process.exit(1);
+  }
+
+  // Check if appagent directory exists
+  if (!fs.existsSync(APPAGENT_SOURCE)) {
+    log(`Error: appagent directory not found at ${APPAGENT_SOURCE}`, 'red');
+    process.exit(1);
+  }
+
+  // Get commit message from CLI args or prompt
+  let commitMessage = '';
+  const messageArg = process.argv.find(arg => arg.startsWith('--message='));
+
+  if (messageArg) {
+    commitMessage = messageArg.split('=')[1];
+  } else if (process.argv.includes('--message') || process.argv.includes('-m')) {
+    const index = Math.max(
+      process.argv.indexOf('--message'),
+      process.argv.indexOf('-m')
+    );
+    commitMessage = process.argv[index + 1] || '';
+  }
+
+  // Create temporary directory
+  const tempDir = path.join(os.tmpdir(), `appagent-sync-${Date.now()}`);
+  log(`\n📁 Creating temporary directory: ${tempDir}`, 'blue');
+  fs.mkdirSync(tempDir, { recursive: true });
+
+  try {
+    // Clone repository
+    log('\n📥 Cloning AppAgent repository...', 'blue');
+    await runCommand('git', ['clone', REPO_URL, tempDir]);
+
+    // Copy appagent files to cloned repository
+    log('\n📋 Copying appagent files...', 'blue');
+    copyDirectory(APPAGENT_SOURCE, tempDir);
+
+    // Check for changes
+    log('\n🔍 Checking for changes...', 'blue');
+    const { stdout: statusOutput } = await runCommand('git', ['status', '--porcelain'], {
+      cwd: tempDir,
+      silent: true
+    });
+
+    if (!statusOutput.trim()) {
+      log('\n✅ No changes to sync', 'green');
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      return;
+    }
+
+    // Display changes
+    log('\n📝 Changes detected:', 'yellow');
+    await runCommand('git', ['status'], { cwd: tempDir });
+
+    // Get commit message if not provided
+    if (!commitMessage) {
+      log('', 'reset');
+      commitMessage = await promptCommitMessage();
+
+      if (!commitMessage) {
+        log('\n❌ Commit message is required', 'red');
+        fs.rmSync(tempDir, { recursive: true, force: true });
+        process.exit(1);
+      }
+    }
+
+    // Add all changes
+    log('\n➕ Staging changes...', 'blue');
+    await runCommand('git', ['add', '.'], { cwd: tempDir });
+
+    // Commit changes
+    log('\n💾 Creating commit...', 'blue');
+    await runCommand('git', ['commit', '-m', commitMessage], { cwd: tempDir });
+
+    // Push changes
+    log('\n🚀 Pushing to remote repository...', 'blue');
+    await runCommand('git', ['push', 'origin', 'main'], { cwd: tempDir });
+
+    log('\n✅ Successfully synced appagent to AppAgent repository!', 'green');
+    log(`   Commit message: "${commitMessage}"`, 'cyan');
+
+  } catch (error) {
+    log(`\n❌ Error: ${error.message}`, 'red');
+    process.exit(1);
+  } finally {
+    // Clean up temporary directory
+    log('\n🧹 Cleaning up temporary directory...', 'blue');
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    log('━'.repeat(50), 'cyan');
+  }
+}
+
+// Run the script
+main().catch((error) => {
+  log(`\n❌ Unexpected error: ${error.message}`, 'red');
+  process.exit(1);
+});


### PR DESCRIPTION
Add a script to synchronize changes from the local appagent/ folder
to the original AppAgent repository.

Features:
- Clone AppAgent repository to temporary directory
- Copy appagent/ contents (excluding .git, __pycache__, etc.)
- Interactive or CLI-based commit message input
- Automatic push to origin/main
- Proper cleanup of temporary directory

Usage:
- Interactive: npm run appagent:sync
- With message: npm run appagent:sync -- -m "commit message"

Also added scripts/README.md with documentation for all scripts.