### PR TITLE
Refactor model test connection to use Python

### DIFF
--- a/appagent/scripts/llm_service.py
+++ b/appagent/scripts/llm_service.py
@@ -108,11 +108,11 @@ Text to translate:
         return {"success": False, "error": str(e)}
 
 
-def chat_completion(prompt: str, model: str, api_key: str = "", base_url: str = "", 
+def chat_completion(prompt: str, model: str, api_key: str = "", base_url: str = "",
                     temperature: float = 0.7, max_tokens: int = 4096) -> dict:
     """
     Generic chat completion using LiteLLM.
-    
+
     Args:
         prompt: User prompt
         model: LiteLLM model name
@@ -120,13 +120,13 @@ def chat_completion(prompt: str, model: str, api_key: str = "", base_url: str = 
         base_url: Optional custom base URL
         temperature: Sampling temperature
         max_tokens: Maximum tokens in response
-    
+
     Returns:
         dict with 'success', 'content' or 'error'
     """
     if not LITELLM_AVAILABLE:
         return {"success": False, "error": "LiteLLM not installed"}
-    
+
     try:
         completion_params = {
             "model": model,
@@ -135,16 +135,16 @@ def chat_completion(prompt: str, model: str, api_key: str = "", base_url: str = 
             "max_tokens": max_tokens,
             "timeout": 60,
         }
-        
+
         if api_key:
             completion_params["api_key"] = api_key
-        
+
         if base_url and base_url.strip():
             completion_params["api_base"] = base_url
-        
+
         response = completion(**completion_params)
         content = response.choices[0].message.content.strip()
-        
+
         # Extract token usage if available
         usage = {}
         if hasattr(response, 'usage') and response.usage:
@@ -153,20 +153,105 @@ def chat_completion(prompt: str, model: str, api_key: str = "", base_url: str = 
                 "completion_tokens": getattr(response.usage, 'completion_tokens', 0),
                 "total_tokens": getattr(response.usage, 'total_tokens', 0),
             }
-        
+
         return {
             "success": True,
             "content": content,
             "usage": usage,
         }
-        
+
     except Exception as e:
         return {"success": False, "error": str(e)}
 
 
+def test_connection(model: str, api_key: str = "", base_url: str = "") -> dict:
+    """
+    Test model connection by sending a simple prompt.
+
+    This uses LiteLLM which automatically handles:
+    - Provider detection from model name prefix (e.g., 'openrouter/', 'ollama/')
+    - Model name transformation for each provider
+    - API routing and authentication
+
+    Args:
+        model: LiteLLM model name (e.g., 'openrouter/openai/gpt-4o-mini', 'ollama/llama3.2-vision')
+        api_key: API key for the provider
+        base_url: Optional custom base URL (not needed for most providers)
+
+    Returns:
+        dict with 'success', 'message', and optionally 'response_time'
+    """
+    import time
+    import litellm
+
+    # Suppress LiteLLM's verbose output that interferes with JSON parsing
+    litellm.suppress_debug_info = True
+
+    if not LITELLM_AVAILABLE:
+        return {"success": False, "message": "LiteLLM not installed"}
+
+    log_debug(f"Testing connection to model: {model}")
+
+    start_time = time.time()
+
+    try:
+        completion_params = {
+            "model": model,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 20,  # Minimum 16 required by some providers (Azure/OpenRouter)
+            "timeout": 30,
+        }
+
+        if api_key:
+            completion_params["api_key"] = api_key
+            log_debug("API key provided")
+
+        # Note: For providers like OpenRouter, do NOT set api_base
+        # LiteLLM automatically routes based on the model prefix (e.g., 'openrouter/')
+        # Setting api_base causes the model name to be sent as-is without transformation
+        if base_url and base_url.strip():
+            # Only set api_base for providers that need custom endpoints (e.g., Ollama with non-default port)
+            # Skip for OpenRouter - LiteLLM handles it automatically
+            if not model.startswith("openrouter/"):
+                completion_params["api_base"] = base_url
+                log_debug(f"Using custom base URL: {base_url}")
+            else:
+                log_debug("OpenRouter detected: skipping api_base (LiteLLM handles routing)")
+
+        log_debug("Sending test request...")
+
+        response = completion(**completion_params)
+
+        response_time = time.time() - start_time
+
+        # Check if we got a valid response
+        if response.choices and response.choices[0].message.content:
+            log_debug(f"Connection successful in {response_time:.2f}s")
+            return {
+                "success": True,
+                "message": f"Connection successful! Response time: {response_time:.2f}s",
+                "response_time": response_time,
+            }
+        else:
+            return {
+                "success": False,
+                "message": "Empty response from model",
+            }
+
+    except Exception as e:
+        response_time = time.time() - start_time
+        error_msg = str(e)
+        log_debug(f"Connection failed after {response_time:.2f}s: {error_msg}")
+        return {
+            "success": False,
+            "message": error_msg,
+            "response_time": response_time,
+        }
+
+
 def main():
     parser = argparse.ArgumentParser(description="LLM Service using LiteLLM")
-    parser.add_argument("--action", choices=["translate", "chat"], help="Action to perform")
+    parser.add_argument("--action", choices=["translate", "chat", "test"], help="Action to perform")
     parser.add_argument("--text", help="Text to translate or prompt for chat")
     parser.add_argument("--target_lang", help="Target language for translation (ko, ja, en)")
     parser.add_argument("--model", required=True, help="LiteLLM model name")
@@ -221,6 +306,8 @@ def main():
             result = {"success": False, "error": "No prompt provided"}
         else:
             result = chat_completion(text, model, api_key, base_url, temperature, max_tokens)
+    elif action == "test":
+        result = test_connection(model, api_key, base_url)
     else:
         result = {"success": False, "error": f"Unknown action: {action}"}
     

--- a/main/handlers/model.ts
+++ b/main/handlers/model.ts
@@ -11,12 +11,14 @@ import * as http from 'http';
 import { loadAppConfig, saveAppConfig } from '../utils/config-storage';
 import { ModelConfig, isLegacyModelConfig, migrateLegacyModelConfig } from '../types/model';
 import { fetchLiteLLMModels, getChatCompletionsUrl } from '../utils/litellm-providers';
+import { testWithLLM } from '../utils/llm-service';
 
 /**
  * Register all model management handlers
  */
 export function registerModelHandlers(ipcMain: IpcMain): void {
-  // Test model connection
+  // Test model connection via Python/LiteLLM
+  // This uses the unified LLM service which handles all provider-specific logic
   ipcMain.handle('model:testConnection', async (_event, config: ModelConfig) => {
     try {
       // Handle legacy config format
@@ -27,73 +29,29 @@ export function registerModelHandlers(ipcMain: IpcMain): void {
         modelConfig = config;
       }
 
-      // Determine the endpoint URL using shared utility
-      const url = getChatCompletionsUrl(modelConfig.provider, modelConfig.baseUrl);
+      console.log(`[model:testConnection] Testing model: ${modelConfig.model} (provider: ${modelConfig.provider})`);
 
-      const urlObj = new globalThis.URL(url);
-      const protocol = urlObj.protocol === 'https:' ? https : http;
+      // Use Python/LiteLLM service for testing
+      // LiteLLM automatically handles:
+      // - Provider detection from model name prefix (e.g., 'openrouter/', 'ollama/')
+      // - Model name transformation for each provider
+      // - API routing and authentication
+      const result = await testWithLLM(
+        modelConfig.model,
+        modelConfig.apiKey,
+        modelConfig.baseUrl
+      );
 
-      return new Promise<{ success: boolean; message?: string }>((resolve) => {
-        const isOllama = modelConfig.provider === 'ollama';
-        
-        // Build request payload based on provider
-        const postData = isOllama 
-          ? JSON.stringify({
-              model: modelConfig.model.replace('ollama/', ''),  // Remove prefix for Ollama API
-              messages: [{ role: 'user', content: 'Hello' }],
-              stream: false,
-            })
-          : JSON.stringify({
-              model: modelConfig.model,
-              messages: [{ role: 'user', content: 'Hello' }],
-              max_tokens: 50,
-            });
-
-        const options: http.RequestOptions = {
-          hostname: urlObj.hostname,
-          port: urlObj.port || (urlObj.protocol === 'https:' ? 443 : 80),
-          path: urlObj.pathname,
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Content-Length': globalThis.Buffer.byteLength(postData),
-          },
-          timeout: 10000,
-        };
-
-        // Add authorization header for non-Ollama providers
-        if (!isOllama && modelConfig.apiKey) {
-          (options.headers as Record<string, string>)['Authorization'] = `Bearer ${modelConfig.apiKey}`;
-        }
-
-        const req = protocol.request(options, (res) => {
-          let data = '';
-          res.on('data', (chunk) => {
-            data += chunk;
-          });
-          res.on('end', () => {
-            if (res.statusCode === 200 || res.statusCode === 201) {
-              resolve({ success: true, message: 'Connection successful!' });
-            } else {
-              resolve({ success: false, message: `HTTP ${res.statusCode}: ${data}` });
-            }
-          });
-        });
-
-        req.on('error', (error) => {
-          resolve({ success: false, message: error.message });
-        });
-
-        req.on('timeout', () => {
-          req.destroy();
-          resolve({ success: false, message: 'Connection timeout' });
-        });
-
-        req.write(postData);
-        req.end();
-      });
+      if (result.success) {
+        console.log(`[model:testConnection] Success: ${result.message}`);
+        return { success: true, message: result.message || 'Connection successful!' };
+      } else {
+        console.error(`[model:testConnection] Failed: ${result.error}`);
+        return { success: false, message: result.error || 'Connection failed' };
+      }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error';
+      console.error(`[model:testConnection] Error: ${message}`);
       return { success: false, message };
     }
   });

--- a/main/utils/llm-service.ts
+++ b/main/utils/llm-service.ts
@@ -17,10 +17,10 @@ import { spawnBundledPython, getAppagentPath, checkVenvStatus } from './python-r
  * Request interface for LLM service
  */
 export interface LLMServiceRequest {
-  action: 'translate' | 'chat';
-  text: string;
-  target_lang?: string;  // Required for 'translate' action
-  model: string;         // LiteLLM model name (e.g., 'openrouter/openai/gpt-4.1-mini')
+  action: 'translate' | 'chat' | 'test';
+  text?: string;             // Required for 'translate' and 'chat' actions (optional for 'test')
+  target_lang?: string;      // Required for 'translate' action
+  model: string;             // LiteLLM model name (e.g., 'openrouter/openai/gpt-4.1-mini')
   api_key?: string;
   base_url?: string;
   temperature?: number;
@@ -34,6 +34,8 @@ export interface LLMServiceResponse {
   success: boolean;
   translated_text?: string;  // For 'translate' action
   content?: string;          // For 'chat' action
+  message?: string;          // For 'test' action
+  response_time?: number;    // For 'test' action
   usage?: {
     prompt_tokens: number;
     completion_tokens: number;
@@ -185,6 +187,33 @@ export async function translateWithLLM(
   return {
     success: response.success,
     translatedText: response.translated_text,
+    error: response.error,
+  };
+}
+
+/**
+ * Convenience function for testing model connection
+ *
+ * Uses LiteLLM via Python which automatically handles:
+ * - Provider detection from model name prefix (e.g., 'openrouter/', 'ollama/')
+ * - Model name transformation for each provider
+ * - API routing and authentication
+ */
+export async function testWithLLM(
+  model: string,
+  apiKey?: string,
+  baseUrl?: string
+): Promise<{ success: boolean; message?: string; error?: string }> {
+  const response = await callLLMService({
+    action: 'test',
+    model,
+    api_key: apiKey,
+    base_url: baseUrl,
+  });
+
+  return {
+    success: response.success,
+    message: response.message,
     error: response.error,
   };
 }


### PR DESCRIPTION
This refactoring fixes OpenRouter model testing issues by delegating all model connection testing to Python/LiteLLM instead of direct HTTP calls from Electron.

## Problem
OpenRouter models were failing with HTTP 400 errors:
- Error: "openrouter/openai/gpt-4.1-mini-2025-04-14 is not a valid model ID"
- Root cause: Direct HTTP calls sent model ID as-is without provider-specific transformations
- LiteLLM automatically handles model name transformations for each provider

## Solution
Unified model testing through Python/LiteLLM service, matching the pattern used by the translation feature.

## Changes

### Python (appagent/scripts/llm_service.py)
- Added `test_connection()` function that uses LiteLLM completion API
- Handles provider detection and model name transformation automatically
- Suppresses verbose LiteLLM output to prevent JSON parsing issues
- Uses minimum 20 max_tokens (required by Azure/OpenRouter)
- Skips api_base for OpenRouter to allow automatic routing
- Updated main() to handle 'test' action

### TypeScript (main/utils/llm-service.ts)
- Updated LLMServiceRequest interface to include 'test' action
- Made text field optional (not needed for test action)
- Updated LLMServiceResponse interface with message and response_time fields
- Added testWithLLM() convenience function

### TypeScript (main/handlers/model.ts)
- Replaced direct HTTP implementation with testWithLLM() call
- Removed manual provider-specific logic (now handled by LiteLLM)
- Added detailed logging for debugging
- Simplified error handling

## Benefits
1. **Consistency**: Same pattern as translation feature
2. **Reliability**: LiteLLM handles all provider quirks automatically
3. **Maintainability**: Single source of truth for LLM provider logic
4. **Accuracy**: Proper model name transformation for all providers

## Testing
Verified with:
- OpenRouter models
- Ollama models
- OpenAI models (via OpenRouter)